### PR TITLE
Fix Claude buffer jumping to top when editing in other windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
+## [0.2.3] - 2025-05-23
+
+### Fixed
+- Fixed Claude buffer jumping to top when editing in other windows (#8)
+
 ## [0.2.2] - 2025-05-22
 
 ### Added

--- a/claude-code.el
+++ b/claude-code.el
@@ -291,14 +291,13 @@ possible, preventing the scrolling up issue when editing other buffers."
 (defun claude-code--on-window-configuration-change ()
   "Handle window configuration changes for Claude buffer.
 
-Ensures the Claude buffer stays scrolled to the bottom when window
+Ensures the Claude buffer stays scrolled to the bottom when window all
 configuration changes (e.g., when minibuffer opens/closes)."
   (when-let ((claude-buffer (claude-code--get-claude-buffer)))
     (with-current-buffer claude-buffer
       ;; Get all windows showing the Claude buffer
-      (let ((windows (get-buffer-window-list claude-buffer nil t)))
-        (when windows
-          (claude-code--synchronize-scroll windows))))))
+      (if-let ((windows (get-buffer-window-list claude-buffer nil t)))
+        (claude-code--synchronize-scroll windows)))))
 
 (defun claude-code--start (dir &optional arg continue)
   "Start Claude in directory DIR.

--- a/claude-code.el
+++ b/claude-code.el
@@ -315,7 +315,7 @@ conversation."
                             claude-code-program-switches)))
     (with-current-buffer buffer
       (cd dir)
-     ;; (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type
+      ;; (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
       (setq-local eat-term-name claude-code-term-name)
       (let ((process-adaptive-read-buffering nil))
         (apply #'eat-make "claude" claude-code-program nil program-switches))

--- a/claude-code.el
+++ b/claude-code.el
@@ -293,15 +293,12 @@ possible, preventing the scrolling up issue when editing other buffers."
 
 Ensures the Claude buffer stays scrolled to the bottom when window
 configuration changes (e.g., when minibuffer opens/closes)."
-  (when (and (eq (current-buffer) (claude-code--get-claude-buffer))
-             (derived-mode-p 'eat-mode))
-    ;; Get all windows showing the Claude buffer
-    (let ((windows (get-buffer-window-list (current-buffer) nil t)))
-      (dolist (window windows)
-        ;; Move to end of buffer to show latest output
-        (with-selected-window window
-          (goto-char (point-max))
-          (recenter -1))))))
+  (when-let ((claude-buffer (claude-code--get-claude-buffer)))
+    (with-current-buffer claude-buffer
+      ;; Get all windows showing the Claude buffer
+      (let ((windows (get-buffer-window-list claude-buffer nil t)))
+        (when windows
+          (claude-code--synchronize-scroll windows))))))
 
 (defun claude-code--start (dir &optional arg continue)
   "Start Claude in directory DIR.


### PR DESCRIPTION
Attempts to fix issue #8 where the Claude buffer would unexpectedly scroll to the top while editing in other windows.

This seems to prevent much of the annoying jumping around in the Claude buffer, when Claude is outputting text and you are editing in another window. The prompt is kept at the bottom even after window configuration changes (invoking vertico, etc). 