### PR TITLE
Do not set invisible cursor type on start

### DIFF
--- a/claude-code.el
+++ b/claude-code.el
@@ -261,7 +261,7 @@ conversation."
                             claude-code-program-switches)))
     (with-current-buffer buffer
       (cd dir)
-      (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
+     ;; (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type
       (setq-local eat-term-name claude-code-term-name)
       (let ((process-adaptive-read-buffering nil))
         (apply #'eat-make "claude" claude-code-program nil program-switches))


### PR DESCRIPTION
This may resolve the cursor issue in #10. 

Only set the special cursor type when toggling read-only mode. Do not set it on Claude start.