### PR TITLE
Refactor buffer selection and add prefix arg to kill all instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,15 @@ All notable changes to claude-code.el will be documented in this file.
 - Instance memory: Your Claude instance selections are remembered per directory during the current Emacs session
 - Simplified startup behavior: `claude-code` now automatically detects the appropriate directory (project root, current file directory, or default directory)
 - Added prefix arg support to `claude-code-switch-to-buffer` - use `C-u` to see all Claude instances across all directories
+- Added prefix arg support to `claude-code-kill` - use `C-u` to kill ALL Claude instances across all directories
 
 ### Changed
 
 - Claude buffer names now use abbreviated file paths for better readability (e.g., `*claude:~/projects/myapp*`)
+- Reorganized prefix arguments for `claude-code` command:
+  - Single prefix (`C-u`) now switches to buffer after creating (more commonly used)
+  - Double prefix (`C-u C-u`) continues previous conversation (unchanged)
+  - Triple prefix (`C-u C-u C-u`) prompts for project directory (previously single prefix)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ All notable changes to claude-code.el will be documented in this file.
 ### Added
 
 - **New feature**: Launch repository-specific Claude sessions - work on multiple projects simultaneously with separate Claude instances
+- **New feature**: Support for multiple named Claude instances per directory (e.g., one for coding, another for tests)
+  - Prompts for instance name when creating additional instances in the same directory
+  - Buffer names now include instance names: `*claude:/path/to/project:instance-name*`
 - Intelligent instance selection: When switching between directories, claude-code.el prompts to select from existing Claude instances or start a new one
 - Instance memory: Your Claude instance selections are remembered per directory during the current Emacs session
 - Simplified startup behavior: `claude-code` now automatically detects the appropriate directory (project root, current file directory, or default directory)
+- Added prefix arg support to `claude-code-switch-to-buffer` - use `C-u` to see all Claude instances across all directories
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ You need to set your own key binding for the Claude Code command map. The exampl
 
 ### Basic Commands
 
-- `claude-code` (`C-c c c`) - Start Claude 
+- `claude-code` (`C-c c c`) - Start Claude. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), continues previous conversation. With triple prefix (`C-u C-u C-u`), prompts for the project directory
 - `claude-code-toggle` (`C-c c t`) - Toggle Claude window
 - `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer. With prefix arg (`C-u`), shows all Claude instances across all directories
-- `claude-code-kill` (`C-c c k`) - Kill Claude session
+- `claude-code-kill` (`C-c c k`) - Kill Claude session. With prefix arg (`C-u`), kills ALL Claude instances across all directories
 - `claude-code-send-command` (`C-c c s`) - Send command to Claude
 - `claude-code-send-command-with-context` (`C-c c x`) - Send command with current file and line context
 - `claude-code-send-region` (`C-c c r`) - Send the current region or buffer to Claude. With prefix arg (`C-u`), prompts for instructions to add to the text. With double prefix (`C-u C-u`), adds instructions and switches to Claude buffer
@@ -82,7 +82,7 @@ The command automatically detects the current mode and switches to the other:
 The `claude-code` command supports continuing previous conversations using Claude's `--continue`
 flag:
 
-- Double prefix arg (`C-u C-u C-c c c`) - Start Claude in project root and continue previous conversation
+- Double prefix arg (`C-u C-u C-c c c`) - Start Claude and continue previous conversation
 
 This allows you to resume where you left off in your previous Claude session.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You need to set your own key binding for the Claude Code command map. The exampl
 
 - `claude-code` (`C-c c c`) - Start Claude 
 - `claude-code-toggle` (`C-c c t`) - Toggle Claude window
-- `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer
+- `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer. With prefix arg (`C-u`), shows all Claude instances across all directories
 - `claude-code-kill` (`C-c c k`) - Kill Claude session
 - `claude-code-send-command` (`C-c c s`) - Send command to Claude
 - `claude-code-send-command-with-context` (`C-c c x`) - Send command with current file and line context
@@ -116,12 +116,24 @@ The cursor appearance in read-only mode can be customized via the `claude-code-r
 #### Instance Management
 
 - When you start Claude with `claude-code`, it creates an instance for the current directory
-- Buffer names follow the format `*claude:/path/to/directory*` to clearly identify each instance
+- If a Claude instance already exists for the directory, you'll be prompted to name the new instance (e.g., "tests", "docs")
+- Buffer names follow the format:
+  - `*claude:/path/to/directory*` for the default instance
+  - `*claude:/path/to/directory:instance-name*` for named instances (e.g., `*claude:/home/user/project:tests*`)
 - If you're in a directory without a Claude instance but have instances running in other directories, you'll be prompted to select one
 - Your selection is remembered for that directory, so you won't be prompted again
 - To start a new instance instead of selecting an existing one, cancel the prompt with `C-g`
 
-This allows you to have separate Claude conversations for different projects while easily switching between them or sharing a Claude instance across related directories.
+#### Multiple Instances Per Directory
+
+You can run multiple Claude instances for the same directory to support different workflows:
+
+- The first instance in a directory is the "default" instance
+- Additional instances require a name when created (e.g., "tests", "docs", "refactor")
+- When multiple instances exist for a directory, commands that interact with Claude will prompt you to select which instance to use
+- Use `C-u claude-code-switch-to-buffer` to see all Claude instances across all directories (not just the current directory)
+
+This allows you to have separate Claude conversations for different aspects of your work within the same project, such as one instance for writing code and another for writing tests.
 
 ## Customization
 

--- a/claude-code.el
+++ b/claude-code.el
@@ -485,18 +485,21 @@ root directory. Otherwise start in the directory of the current buffer
 file, or the current value of `default-directory' if no project and no
 buffer file.
 
-With single prefix ARG (\\[universal-argument]), prompt for the project directory.
-With double prefix ARG (\\[universal-argument] \\[universal-argument]), continue previous conversation."
+With single prefix ARG (\\[universal-argument]), switch to buffer after creating.
+With double prefix ARG (\\[universal-argument] \\[universal-argument]), continue previous conversation.
+With triple prefix ARG (\\[universal-argument] \\[universal-argument] \\[universal-argument]), prompt for the project directory."
   (interactive "P")
   
   ;; Forward declare variables to avoid compilation warnings
   (require 'eat)
   
-  (let* ((dir (if (and arg (not (equal arg '(16))))
+  (let* ((dir (if (equal arg '(64))  ; Triple prefix
                   (read-directory-name "Project directory: ")
                 (claude-code--directory)))
          (abbreviated-dir (abbreviate-file-name dir))
-         (continue (equal arg '(16))) (default-directory dir)
+         (continue (equal arg '(16))) ; Double prefix
+         (switch-after (equal arg '(4))) ; Single prefix
+         (default-directory dir)
          ;; Check for existing Claude instances in this directory
          (existing-buffers (claude-code--find-claude-buffers-for-directory dir))
          ;; Determine instance name
@@ -549,7 +552,7 @@ With double prefix ARG (\\[universal-argument] \\[universal-argument]), continue
       ;; run start hooks and show the claude buffer
       (run-hooks 'claude-code-start-hook)
       (display-buffer buffer))
-    (when arg
+    (when switch-after
       (switch-to-buffer buffer))))
 
 (defun claude-code--format-errors-at-point ()

--- a/multiple-instances-per-directory-feature.md
+++ b/multiple-instances-per-directory-feature.md
@@ -1,0 +1,22 @@
+# Multiple Instances Per Directory Feature
+
+## Overview
+
+I would like to extend claude-code.el's multiple instance feature to support multiple claude instances for the same directory / project, to support multi-Claude workflows. For example, within the ~/repos/claude-code.el project I would like to be able to run a default Claude instance to write source code, and another instance for writing unit tests. 
+
+## Changes
+
+I would like to make changes to the following commands:
+
+### claude-code
+
+- If no Claude instance is running for the project directory, start a new instance with the name 'default'. If the project directory is ~/repos/claude-code.el, then the claude buffer name for the new instance will be "*claude:~/respo/claude-code.el:default*".
+- If there is a running Claude instance for the directory, prompt the user for a name for the new instance. If the user enters "tests", and the directory is ~/repos/claude-code.el, then the claude buffer name for the new instance will be "*claude:~/respo/claude-code.el:tests*". 
+
+### Adjusting Other Commands
+
+For commands like `claude-code-kill`, `claude-code-switch-to-buffer`, etc, if there are multiple instances running for the project directory, prompt the user for the instance. Currently this is done  via `claude-code--prompt-for-claude-buffer`.
+
+Think about what  changes need to be made to achieve this.
+
+


### PR DESCRIPTION
## Summary

Add support for multiple named Claude instances per directory. 

Minor tweaks to buffer management and prefix argument handling.

Claude description:

## Key Features

### Multiple Named Instances Per Directory
- Run multiple Claude instances in the same directory with different names (e.g., \tests\, \docs\, \refactor\)
- Buffer names include instance names: \
- Prompts for instance name when creating additional instances in an already-active directory

### Improved Buffer Management
- Intelligent instance selection when switching between directories
- Instance selections are remembered per directory during the Emacs session
- \ shows all Claude instances across all directories
- \ kills all Claude instances at once

### Better Prefix Argument Organization
- \: Switch to buffer after creating (most common use case)
- \: Continue previous conversation
- \: Prompt for project directory

## Documentation
- Updated README with comprehensive usage examples
- Updated CHANGELOG with all changes
- All tests pass (\for FILE in claude-code.el; do emacs --batch -L . -eval "(setq sentence-end-double-space nil)" -eval "(checkdoc-file \"$FILE\")" ; done
rm -f *.elc
emacs --batch -L . --eval "(setq sentence-end-double-space nil)" -f batch-byte-compile *.el successful)