### PR TITLE
Fix cursor type in read-only mode customisation example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ In the Claude terminal, you can switch to a read-only mode to select and copy te
 - `C-c C-e` (`eat-emacs-mode`) - Switch to read-only mode with normal Emacs cursor for text selection
 - `C-c C-j` (`semi-char-mode`) - Return to normal terminal mode
 
-The cursor appearance in read-only mode can be customized via the `claude-code-read-only-mode-cursor-type` variable:
+The cursor appearance in read-only mode can be customized via the `claude-code-read-only-mode-cursor-type` variable. This variable uses the format `(CURSOR-ON BLINKING-FREQUENCY CURSOR-OFF)`. For more information, run `M-x describe-variable RET claude-code-read-only-mode-cursor-type RET`.
 
 ```elisp
-;; Customize cursor type in read-only mode (default is 'box)
-;; Options: 'box, 'hollow, 'bar, 'hbar, or nil
-(setq claude-code-read-only-mode-cursor-type 'bar)
+;; Customize cursor type in read-only mode (default is '(box nil nil))
+;; Cursor type options: 'box, 'hollow, 'bar, 'hbar, or nil
+(setq claude-code-read-only-mode-cursor-type '(bar nil nil))
 ```
 
 ### Multiple Claude Instances


### PR DESCRIPTION
Currently, the example from `README.md`

```elisp
(setq claude-code-read-only-mode-cursor-type 'bar)
```

fails due to

```
Debugger entered--Lisp error: (wrong-type-argument listp bar)
  car(bar)
  eat--set-cursor(nil :invisible)
  claude-code-read-only-mode()
  claude-code-toggle-read-only-mode()
  funcall-interactively(claude-code-toggle-read-only-mode)
  call-interactively(claude-code-toggle-read-only-mode nil nil)
  command-execute(claude-code-toggle-read-only-mode)
```

The variable appears to be a list instead of a symbol.