### PR TITLE
Add vterm backend support

### DIFF
--- a/claude-code.el
+++ b/claude-code.el
@@ -624,7 +624,7 @@ This function handles the proper cleanup sequence for a Claude buffer:
 3. Kill the buffer"
   (with-current-buffer buffer
     (remove-hook 'window-configuration-change-hook #'claude-code--on-window-configuration-change t)
-    (eat-kill-process)
+    (claude-code--term-kill-process)
     (kill-buffer buffer)))
 
 (defun claude-code--cleanup-directory-mapping ()
@@ -651,8 +651,7 @@ Returns the selected Claude buffer or nil."
   (if-let ((claude-code-buffer (claude-code--get-or-prompt-for-buffer)))
       (progn
         (with-current-buffer claude-code-buffer
-          (eat-term-send-string eat-terminal cmd)
-          (eat-term-send-string eat-terminal (kbd "RET"))
+          (claude-code--term-send-string cmd)
           (display-buffer claude-code-buffer))
         claude-code-buffer)
     (claude-code--show-not-running-message)
@@ -1043,7 +1042,7 @@ having to switch to the REPL buffer."
   (interactive)
   (if-let ((claude-code-buffer (claude-code--get-or-prompt-for-buffer)))
       (with-current-buffer claude-code-buffer
-        (eat-term-send-string eat-terminal (kbd "ESC"))
+        (claude-code--term-send-key "<escape>")
         (display-buffer claude-code-buffer))
     (claude-code--show-not-running-message)))
 
@@ -1058,7 +1057,7 @@ Claude uses Shift-Tab to cycle through:
   (interactive)
   (if-let ((claude-code-buffer (claude-code--get-or-prompt-for-buffer)))
       (with-current-buffer claude-code-buffer
-        (eat-term-send-string eat-terminal "\e[Z")
+        (claude-code--term-send-key "\e[Z")
         (display-buffer claude-code-buffer))
     (claude-code--show-not-running-message)))
 
@@ -1106,9 +1105,7 @@ Use `claude-code-exit-read-only-mode' to switch back to normal mode."
   (interactive)
   (if-let ((claude-code-buffer (claude-code--get-or-prompt-for-buffer)))
       (with-current-buffer claude-code-buffer
-        (eat-emacs-mode)
-        (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
-        (eat--set-cursor nil :invisible)
+        (claude-code--term-enter-read-only-mode)
         (message "Claude read-only mode enabled"))
     (claude-code--show-not-running-message)))
 
@@ -1118,9 +1115,7 @@ Use `claude-code-exit-read-only-mode' to switch back to normal mode."
   (interactive)
   (if-let ((claude-code-buffer (claude-code--get-or-prompt-for-buffer)))
       (with-current-buffer claude-code-buffer
-        (eat-semi-char-mode)
-        (setq-local eat-invisible-cursor-type nil)
-        (eat--set-cursor nil :invisible)
+        (claude-code--term-exit-read-only-mode)
         (message "Claude semi-char mode enabled"))
     (claude-code--show-not-running-message)))
 

--- a/claude-code.el
+++ b/claude-code.el
@@ -660,12 +660,17 @@ If not in a project and no buffer file, raise an error."
 
 This function handles the proper cleanup sequence for a Claude buffer:
 1. Remove the window configuration change hook
-2. Kill the eat process
-3. Kill the buffer"
+2. Kill the terminal process
+3. Kill the buffer without prompting"
   (with-current-buffer buffer
     (remove-hook 'window-configuration-change-hook #'claude-code--on-window-configuration-change t)
+    ;; Kill the process first
     (claude-code--term-kill-process)
-    (kill-buffer buffer)))
+    ;; Set buffer-modified-p to nil to avoid save prompts
+    (set-buffer-modified-p nil)
+    ;; Let kill-buffer-query-functions skip process check
+    (let ((kill-buffer-query-functions nil))
+      (kill-buffer buffer))))
 
 (defun claude-code--cleanup-directory-mapping ()
   "Remove entries from directory-buffer map when this buffer is killed.

--- a/claude-code.el
+++ b/claude-code.el
@@ -450,15 +450,13 @@ SWITCHES are command line arguments for the program."
 BUFFER-NAME is the name for the terminal buffer (unused by vterm).
 PROGRAM is the program to run.
 SWITCHES are command line arguments for the program."
-  ;; vterm doesn't support switches in the same way as eat
-  ;; We'll need to handle this differently
-  (setq-local vterm-shell program)
+  ;; vterm starts a shell, so we need to construct a command to run claude
   (vterm-mode)
-  ;; If there are switches, we might need to send them as a command
-  ;; after vterm starts, or construct a shell command
-  (when switches
-    ;; For now, construct a shell command if there are switches
-    (vterm-send-string (concat program " " (mapconcat #'identity switches " ")))
+  ;; Run the program with switches
+  (let ((command (if switches
+                     (concat program " " (mapconcat #'identity switches " "))
+                   program)))
+    (vterm-send-string command)
     (vterm-send-return)))
 
 (defun claude-code--vterm-send-string (string)

--- a/claude-code.el.bak
+++ b/claude-code.el.bak
@@ -174,9 +174,6 @@ outputs."
 ;; Forward declare vterm functions
 (defvar vterm-shell)
 (defvar vterm-max-scrollback)
-(defvar vterm-buffer-name-string)
-(defvar vterm-scroll-to-bottom-on-output)
-(defvar vterm-copy-mode)
 (declare-function vterm-mode "vterm")
 (declare-function vterm-send-string "vterm")
 (declare-function vterm-send-return "vterm")
@@ -185,8 +182,6 @@ outputs."
 (declare-function vterm-send-backspace "vterm")
 (declare-function vterm-send-key "vterm")
 (declare-function vterm-copy-mode "vterm")
-(declare-function vterm--set-title "vterm")
-(declare-function vterm--window-adjust-process-window-size "vterm")
 
 ;; Forward declare flycheck functions
 (declare-function flycheck-overlay-errors-at "flycheck")
@@ -448,17 +443,8 @@ SWITCHES are command line arguments for the program."
 (defvar claude-code--window-widths (make-hash-table :test 'eq :weakness 'key)
   "Hash table mapping windows to their last known widths.")
 
-(defun claude-code--vterm-set-title-override (_title)
-  "Override vterm's title setting to prevent buffer renaming.
-
-This function is used as advice to prevent vterm from changing
-the buffer name when terminal programs set the window title.
-The _TITLE argument is ignored."
-  ;; Do nothing - we want to keep our buffer name
-  nil)
-
 (defun claude-code--vterm-window-size-change (_frame)
-  "Handle window size change for vterm buffers.
+  "Handle window size changes for vterm buffers.
   
 This function is called when window size changes. It ensures vterm
 properly adjusts to the new window dimensions. The _FRAME argument
@@ -487,12 +473,10 @@ is ignored as we operate on the current buffer."
   ;; Add window size change hook for vterm to handle resizing
   (add-hook 'window-size-change-functions #'claude-code--vterm-window-size-change nil t)
   ;; Add advice to only adjust on width changes
-  (advice-add 'vterm--window-adjust-process-window-size
+  (advice-add 'vterm--window-adjust-process-window-size 
               :around #'claude-code--vterm-adjust-process-window-size-advice)
   ;; Add post-command hook to synchronize scrolling
-  (add-hook 'post-command-hook #'claude-code--vterm-synchronize-scroll nil t)
-  ;; Prevent vterm from changing buffer name via title updates
-  (advice-add 'vterm--set-title :override #'claude-code--vterm-set-title-override))
+  (add-hook 'post-command-hook #'claude-code--vterm-synchronize-scroll nil t))
 
 (defun claude-code--vterm-make (_buffer-name program switches)
   "Create a vterm terminal.
@@ -567,8 +551,7 @@ the minibuffer opens/closes."
   "Advice for `vterm--window-adjust-process-window-size' to reduce flickering.
 
 Only calls ORIG-FUN when the window width actually changes, not just height.
-This prevents unnecessary terminal reflows when the minibuffer opens/closes.
-ARGS are passed to ORIG-FUN."
+This prevents unnecessary terminal reflows when the minibuffer opens/closes."
   (let* ((windows (get-buffer-window-list (current-buffer) nil t))
          (width-changed nil))
     ;; Check if any window width has changed
@@ -775,12 +758,7 @@ the remembered directory->buffer associations."
     (maphash (lambda (dir buffer)
                (when (eq buffer dying-buffer)
                  (remhash dir claude-code--directory-buffer-map)))
-             claude-code--directory-buffer-map))
-  ;; Clean up vterm-specific advice if using vterm backend
-  (when (eq claude-code-terminal-backend 'vterm)
-    (advice-remove 'vterm--set-title #'claude-code--vterm-set-title-override)
-    (advice-remove 'vterm--window-adjust-process-window-size
-                   #'claude-code--vterm-adjust-process-window-size-advice)))
+             claude-code--directory-buffer-map)))
 
 (defun claude-code--get-buffer-file-name ()
   "Get the file name associated with the current buffer."
@@ -1214,7 +1192,7 @@ Sends <escape><escape> to the Claude Code REPL."
   (interactive)
   (if-let ((claude-code-buffer (claude-code--get-or-prompt-for-buffer)))
       (with-current-buffer claude-code-buffer
-        (claude-code--term-send-key "")
+        (claude-code--send-key "")
         (display-buffer claude-code-buffer))
     (error "Claude is not running")))
 

--- a/vterm.md
+++ b/vterm.md
@@ -1,0 +1,198 @@
+# Claude-code.el Vterm Support Implementation Plan
+
+## Executive Summary
+This document outlines a comprehensive plan for adding vterm support to claude-code.el as an alternative to the current eat terminal emulator. Users will be able to choose between eat and vterm through a customization variable.
+
+## Analysis Summary
+
+### Current eat Implementation
+- **Terminal Creation**: Uses `eat-make` with program name and switches
+- **Command Sending**: Uses `eat-term-send-string` with eat-terminal object
+- **Mode Switching**: Uses `eat-semi-char-mode` and `eat-emacs-mode`
+- **Process Management**: Uses `eat-kill-process`
+- **Terminal State**: eat.el provides and sets `eat-terminal` buffer-local variable
+- **Scrolling**: Custom synchronization function via `eat--synchronize-scroll-function` (workaround for eat scrolling issues)
+- **Window Resizing**: Custom advice on `eat--adjust-process-window-size` (prevents unnecessary reflows)
+- **Scrollback**: Option to disable truncation via `eat-term-scrollback-size`
+
+### vterm Differences
+- **Terminal Creation**: Uses `vterm-mode` which internally creates the process
+- **Command Sending**: Uses `vterm-send-string` and `vterm-send-key`
+- **Mode Switching**: Uses `vterm-copy-mode` for read-only mode
+- **Process Management**: Process stored in `vterm--process`
+- **Terminal State**: Internal terminal object in `vterm--term`
+- **Different API**: No direct equivalent to some eat functions
+
+## Implementation Strategy
+
+### 1. Add Terminal Backend Selection
+```elisp
+(defcustom claude-code-terminal-backend 'eat
+  "Terminal backend to use for Claude Code.
+Can be either 'eat or 'vterm."
+  :type '(choice (const :tag "Eat terminal" eat)
+                 (const :tag "Vterm terminal" vterm))
+  :group 'claude-code)
+```
+
+### 2. Create Abstraction Layer
+Create terminal-agnostic functions that dispatch to the appropriate backend:
+
+```elisp
+;; Generic terminal interface functions
+(defun claude-code--term-make (buffer-name program switches)
+  "Create a terminal using the configured backend.")
+
+(defun claude-code--term-send-string (string)
+  "Send STRING to the terminal.")
+
+(defun claude-code--term-send-key (key)
+  "Send KEY to the terminal.")
+
+(defun claude-code--term-kill-process ()
+  "Kill the terminal process.")
+
+(defun claude-code--term-enter-read-only-mode ()
+  "Enter read-only/copy mode.")
+
+(defun claude-code--term-exit-read-only-mode ()
+  "Exit read-only/copy mode.")
+```
+
+### 3. Implementation Details
+
+#### 3.1 Terminal Creation
+- **eat**: Current implementation with `eat-make`
+- **vterm**: 
+  ```elisp
+  (with-current-buffer buffer
+    (vterm-mode)
+    ;; vterm automatically starts the process
+    ;; Configure vterm-specific settings
+    (setq vterm-shell program)
+    ;; Handle program switches differently as vterm doesn't 
+    ;; directly support switches like eat does
+    )
+  ```
+
+#### 3.2 Sending Commands
+- **eat**: `(eat-term-send-string eat-terminal string)`
+- **vterm**: `(vterm-send-string string)`
+
+#### 3.3 Sending Special Keys
+- **eat**: `(eat-term-send-string eat-terminal (kbd "ESC"))`
+- **vterm**: `(vterm-send-key "<escape>")`
+
+#### 3.4 Read-only Mode
+- **eat**: `eat-emacs-mode` / `eat-semi-char-mode`
+- **vterm**: `vterm-copy-mode`
+
+### 4. Challenges and Solutions
+
+**Note**: Some complexity in the current implementation exists to work around eat.el issues (scrolling, window resizing, scrollback truncation). Vterm may not need equivalent workarounds, which could simplify the implementation.
+
+#### 4.1 Program Switches
+**Challenge**: vterm doesn't support program switches directly in the same way eat does.
+**Solution**: 
+- For simple cases, append switches to the shell command
+- For `--continue`, might need to send as a command after terminal starts
+- May need custom handling per switch
+
+#### 4.2 Terminal Object Access
+**Challenge**: eat requires passing `eat-terminal` to many functions, vterm's API needs investigation
+**Solution**: 
+- Investigate if vterm functions require terminal object access
+- Many vterm functions appear to work on the current buffer without explicit terminal object
+- Store backend type in buffer-local variable if needed
+- Abstract terminal object access only if vterm requires it
+
+#### 4.3 Window Synchronization
+**Challenge**: Custom scroll synchronization in eat vs vterm's built-in handling
+**Solution**: 
+- The custom scroll sync in claude-code.el is a workaround for eat.el issues
+- For vterm, we may be able to rely on its built-in window handling
+- Test if vterm needs any custom synchronization at all
+
+#### 4.4 Cursor Management
+**Challenge**: Different cursor handling between eat and vterm
+**Solution**: 
+- Abstract cursor operations
+- Use vterm's `vterm-reset-cursor-point` equivalent functionality
+
+### 5. Implementation Phases
+
+#### Phase 1: Core Abstraction (Priority: High)
+1. Add `claude-code-terminal-backend` customization variable
+2. Create abstraction functions for basic operations
+3. Refactor existing code to use abstractions
+4. Test with eat to ensure no regression
+
+#### Phase 2: Basic vterm Support (Priority: High)
+1. Implement vterm backend for core functions:
+   - Terminal creation
+   - Sending strings/commands
+   - Process termination
+2. Handle buffer naming and directory setup
+3. Basic testing with vterm
+
+#### Phase 3: Advanced Features (Priority: Medium)
+1. Read-only mode support for vterm
+2. Special key handling (escape, return, etc.)
+3. Window management and synchronization
+4. Handle program switches appropriately
+
+#### Phase 4: Polish and Edge Cases (Priority: Low)
+1. Terminal resizing handling
+2. Face/theme support
+3. Performance optimizations
+4. Comprehensive testing
+
+### 6. Code Structure
+
+```
+claude-code.el
+├── Customization
+│   └── claude-code-terminal-backend
+├── Terminal Abstraction Layer
+│   ├── claude-code--term-make
+│   ├── claude-code--term-send-string
+│   ├── claude-code--term-send-key
+│   ├── claude-code--term-kill-process
+│   └── claude-code--term-*-mode
+├── Backend Implementations
+│   ├── eat backend functions
+│   └── vterm backend functions
+└── Core Functions (refactored to use abstraction)
+```
+
+### 7. Testing Strategy
+
+1. **Compatibility Testing**: Ensure eat backend works exactly as before
+2. **Feature Parity**: Test all features work with both backends
+3. **Edge Cases**: 
+   - Multiple instances
+   - Directory switching
+   - Special characters
+   - Large output handling
+4. **Performance**: Compare performance between eat and vterm
+
+### 8. Migration Guide for Users
+
+```elisp
+;; To use vterm instead of eat:
+(setq claude-code-terminal-backend 'vterm)
+
+;; Ensure vterm is installed:
+;; M-x package-install RET vterm RET
+```
+
+### 9. Future Considerations
+
+1. **Dynamic Backend Switching**: Allow switching backends without restarting Emacs
+2. **Backend Feature Detection**: Automatically detect available backends
+3. **Backend-Specific Optimizations**: Take advantage of unique features in each backend
+4. **Additional Backends**: Structure allows for future terminal emulators
+
+## Conclusion
+
+This implementation plan provides a clean abstraction layer that allows claude-code.el to support multiple terminal backends while maintaining backward compatibility. The phased approach ensures that basic functionality can be delivered quickly while more complex features are implemented incrementally.


### PR DESCRIPTION
## Summary
WIP implementation of optional vterm backend. To enable:

```elisp
(setq claude-code-terminal-backend 'vterm)
```

There are bugs, and it flickers. I've fixed the flickering issues with the eat backend, but vterm introduces similar issues. I'll see if I can resolve them in vterm. 

Long term, I haven't decided if I want to merge this and support two backends or not. It does complicate the code base. But it would be nice to support vterm as an option. We'll see. 

## Related Issues
#18

## Test plan
- [ ] Test with eat backend (default)
- [ ] Test with vterm backend via `(setq claude-code-terminal-backend 'vterm)`
- [ ] Verify terminal switching works correctly
- [ ] Ensure no regression in existing eat functionality
- [ ] Test buffer management and cleanup