### PR TITLE
Add session management and UI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
-## [Unreleased]
+## [0.3.9]
 
 ### Added
 
@@ -50,11 +50,6 @@ All notable changes to claude-code.el will be documented in this file.
   - Removed support for continuing conversations (use `claude-code-continue` instead)
 - `claude-code-kill` no longer accepts prefix arguments
   - Use the new `claude-code-kill-all` command to kill all instances
-
-### Fixed
-
-- Fixed startup error "Symbol's function definition is void: (setf eat-term-parameter)" that occurred when starting claude-code for the first time
-  - Added proper compile-time handling of eat package dependencies
 
 ## [0.3.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ All notable changes to claude-code.el will be documented in this file.
 - New `claude-code-continue` command to explicitly continue previous conversations
   - Bound to `C-c c C` in the command map
   - Supports same prefix arguments as `claude-code` command
+- New `claude-code-resume` command to resume specific past sessions
+  - Bound to `C-c c R` in the command map
+  - Allows resuming any past session from an interactive list
+  - Can programmatically resume a specific session by ID
+  - Supports same prefix arguments as `claude-code` command
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ All notable changes to claude-code.el will be documented in this file.
   - Bound to `C-c c d` in the command map
   - Always prompts for directory (equivalent to `C-u C-u claude-code`)
   - With prefix arg, switches to buffer after creating
+- New `claude-code-new-instance` command to create a new Claude instance with a custom name
+  - Bound to `C-c c i` in the command map
+  - Always prompts for instance name (unlike `claude-code` which uses "default" for the first instance)
+  - Supports same prefix arguments as `claude-code` command
 
 ### Changed
 
@@ -36,6 +40,11 @@ All notable changes to claude-code.el will be documented in this file.
   - Single prefix (`C-u`) now switches to buffer after creating
   - Double prefix (`C-u C-u`) now prompts for project directory
   - Removed support for continuing conversations (use `claude-code-continue` instead)
+
+### Fixed
+
+- Fixed startup error "Symbol's function definition is void: (setf eat-term-parameter)" that occurred when starting claude-code for the first time
+  - Added proper compile-time handling of eat package dependencies
 
 ## [0.3.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- New `claude-code-newline-keybinding-style` customization variable to configure how return and modifier keys behave in Claude buffers
+  - `'default` (default): M-return inserts newline, RET sends message
+  - `'newline-on-return`: RET inserts newline, M-return sends message
+  - `'newline-on-shift-return`: RET sends message, S-return inserts newline
+  - `'super-return-to-send`: RET inserts newline, s-return sends message
+- Single ESC key now works as expected in Claude buffers for canceling operations
+- C-g can be used as an alternative to ESC for canceling in Claude buffers
+
+### Changed
+
+- Renamed internal variable from `claude-code-key-binding-style` to `claude-code-newline-keybinding-style` for clarity
+
 ## [0.3.8]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to claude-code.el will be documented in this file.
   - Bound to `C-c c i` in the command map
   - Always prompts for instance name (unlike `claude-code` which uses "default" for the first instance)
   - Supports same prefix arguments as `claude-code` command
+- New `claude-code-select-buffer` command to select from all Claude instances
+  - Bound to `C-c c B` in the command map
+  - Shows all Claude instances across all projects and directories
+  - Provides a dedicated command for global instance selection (similar to `C-u claude-code-switch-to-buffer`)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to claude-code.el will be documented in this file.
   - Allows resuming any past session from an interactive list
   - Can programmatically resume a specific session by ID
   - Supports same prefix arguments as `claude-code` command
+- New `claude-code-start-in-directory` command for convenience
+  - Bound to `C-c c d` in the command map
+  - Always prompts for directory (equivalent to `C-u C-u claude-code`)
+  - With prefix arg, switches to buffer after creating
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,20 @@ All notable changes to claude-code.el will be documented in this file.
   - `'super-return-to-send`: RET inserts newline, s-return sends message
 - Single ESC key now works as expected in Claude buffers for canceling operations
 - C-g can be used as an alternative to ESC for canceling in Claude buffers
+- New `claude-code-confirm-kill` customization variable to control kill confirmation prompts
+  - When `t` (default), prompts for confirmation before killing Claude instances
+  - When `nil`, kills Claude instances without confirmation
+- New `claude-code-continue` command to explicitly continue previous conversations
+  - Bound to `C-c c C` in the command map
+  - Supports same prefix arguments as `claude-code` command
 
 ### Changed
 
 - Renamed internal variable from `claude-code-key-binding-style` to `claude-code-newline-keybinding-style` for clarity
+- Simplified `claude-code` command prefix arguments:
+  - Single prefix (`C-u`) now switches to buffer after creating
+  - Double prefix (`C-u C-u`) now prompts for project directory
+  - Removed support for continuing conversations (use `claude-code-continue` instead)
 
 ## [0.3.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to claude-code.el will be documented in this file.
   - Bound to `C-c c B` in the command map
   - Shows all Claude instances across all projects and directories
   - Provides a dedicated command for global instance selection (similar to `C-u claude-code-switch-to-buffer`)
+- New `claude-code-kill-all` command to kill all Claude instances
+  - Bound to `C-c c K` in the command map
+  - Kills all Claude instances across all projects and directories
+  - Provides dedicated functionality previously available via `C-u claude-code-kill`
 
 ### Changed
 
@@ -44,6 +48,8 @@ All notable changes to claude-code.el will be documented in this file.
   - Single prefix (`C-u`) now switches to buffer after creating
   - Double prefix (`C-u C-u`) now prompts for project directory
   - Removed support for continuing conversations (use `claude-code-continue` instead)
+- `claude-code-kill` no longer accepts prefix arguments
+  - Use the new `claude-code-kill-all` command to kill all instances
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,17 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 ## Features
 
 - Start, stop, and toggle Claude Code sessions directly from Emacs
+- Continue and resume previous Claude Code conversations
 - Support for multiple Claude instances across different projects and directories
-- Send commands to Claude with or without file/line context
+- Send commands or region to Claude from normal Emacs buffers or the minibuffer, with or without
+  file/line context 
+- Send quick responses to Claude from Emacs minibuffer - cycle accept edits / plan mode, quick commands to send yes, no, 1, 2, 3, etc to Claude.
 - Quick access to all Claude slash commands via transient menus
-- Customizable key bindings and appearance settings
+- Fix error at point - Send flycheck or flymake error at point to Claude, have Claude fix it.
+- Commands to show, hide, switch to Claude terminal buffers
+- Claude terminal niceties - `C-g` to quit/escape, 3 options for entering newlines and submitting.
 - Desktop notifications when Claude finishes processing and awaits input
+- Customizable key bindings and appearance settings
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You need to set your own key binding for the Claude Code command map. The exampl
 - `claude-code` (`C-c c c`) - Start Claude. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
 - `claude-code-continue` (`C-c c C`) - Start Claude and continue the previous conversation. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
 - `claude-code-resume` (`C-c c R`) - Resume a specific Claude session by ID or choose interactively. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
+- `claude-code-new-instance` (`C-c c i`) - Create a new Claude instance with a custom name. Always prompts for instance name, unlike `claude-code` which uses "default" when no instances exist. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
 - `claude-code-start-in-directory` (`C-c c d`) - Prompt for a directory and start Claude there. With prefix arg (`C-u`), switches to the Claude buffer after creating
 - `claude-code-toggle` (`C-c c t`) - Toggle Claude window
 - `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer. With prefix arg (`C-u`), shows all Claude instances across all directories
@@ -141,6 +142,7 @@ The cursor appearance in read-only mode can be customized via the `claude-code-r
 
 - When you start Claude with `claude-code`, it creates an instance for the current directory
 - If a Claude instance already exists for the directory, you'll be prompted to name the new instance (e.g., "tests", "docs")
+- You can also use `claude-code-new-instance` to explicitly create a new instance with a custom name
 - Buffer names follow the format:
   - `*claude:/path/to/directory*` for the default instance
   - `*claude:/path/to/directory:instance-name*` for named instances (e.g., `*claude:/home/user/project:tests*`)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ You can control how the Claude Code window appears using Emacs' `display-buffer-
 
 ```elisp
 (add-to-list 'display-buffer-alist
-                 `("^\\*claude"
+                 '("^\\*claude"
                    (display-buffer-in-side-window)
                    (side . right)
                    (window-width . ,width)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ You need to set your own key binding for the Claude Code command map. The exampl
 - `claude-code-toggle` (`C-c c t`) - Toggle Claude window
 - `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer. With prefix arg (`C-u`), shows all Claude instances across all directories
 - `claude-code-select-buffer` (`C-c c B`) - Select and switch to a Claude buffer from all running instances across all projects and directories
-- `claude-code-kill` (`C-c c k`) - Kill Claude session. With prefix arg (`C-u`), kills ALL Claude instances across all directories
+- `claude-code-kill` (`C-c c k`) - Kill Claude session
+- `claude-code-kill-all` (`C-c c K`) - Kill ALL Claude instances across all directories
 - `claude-code-send-command` (`C-c c s`) - Send command to Claude
 - `claude-code-send-command-with-context` (`C-c c x`) - Send command with current file and line context
 - `claude-code-send-region` (`C-c c r`) - Send the current region or buffer to Claude. With prefix arg (`C-u`), prompts for instructions to add to the text. With double prefix (`C-u C-u`), adds instructions and switches to Claude buffer

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ This allows you to have separate Claude conversations for different aspects of y
 
 ;; Customize the notification function (default is claude-code--default-notification)
 ;; The function should accept two arguments: title and message
-;; The default function tries notifications-notify, then alert package, then message
+;; The default function displays a message and pulses the modeline for visual feedback
 (setq claude-code-notification-function 'claude-code--default-notification)
 
 ;; Example: Use your own notification function

--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ With a single prefix arg, `claude-code`, `claude-code-send-command` and
 `claude-code-send-command-with-context` will switch to the Claude terminal buffer after sending the
 command.
 
+### Keybindings in Claude Buffers
 
+In Claude buffers, the ESC key now works as expected - a single press sends an escape character to Claude. This is useful for canceling operations or saying "No" to Claude prompts. You can also use `C-g` as an alternative way to send escape/cancel.
+
+The behavior of the return key and its modifiers can be customized using the `claude-code-newline-keybinding-style` variable. By default, pressing RET sends your message to Claude while M-return (Meta/Alt + Return) inserts a newline. This can be changed to match your preferences - for example, you can configure it so that RET inserts newlines and M-return sends the message, or use Shift-return or Super-return for newlines. See the Customization section for available options.
 
 ### Read-Only Mode Toggle
 
@@ -182,6 +186,14 @@ This allows you to have separate Claude conversations for different aspects of y
 ;; When set to t, claude-code.el can output display content without truncation
 ;; This is useful when working with large Claude buffers
 (setq claude-code-never-truncate-claude-buffer t)
+
+;; Configure key binding style for entering newlines and sending messages in Claude buffers
+;; Available styles:
+;;   'default              - M-return inserts newline, RET sends message (default)
+;;   'newline-on-return    - RET inserts newline, M-return sends message
+;;   'newline-on-shift-return - RET sends message, S-return inserts newline
+;;   'super-return-to-send - RET inserts newline, s-return sends message
+(setq claude-code-newline-keybinding-style 'default)
 ```
 
 ### Customizing Window Position

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 - Send commands to Claude with or without file/line context
 - Quick access to all Claude slash commands via transient menus
 - Customizable key bindings and appearance settings
+- Desktop notifications when Claude finishes processing and awaits input
 
 ## Installation
 
@@ -194,6 +195,21 @@ This allows you to have separate Claude conversations for different aspects of y
 ;;   'newline-on-shift-return - RET sends message, S-return inserts newline
 ;;   'super-return-to-send - RET inserts newline, s-return sends message
 (setq claude-code-newline-keybinding-style 'default)
+
+;; Enable or disable notifications when Claude finishes and awaits input (default is t)
+(setq claude-code-enable-notifications t)
+
+;; Customize the notification function (default is claude-code--default-notification)
+;; The function should accept two arguments: title and message
+;; The default function tries notifications-notify, then alert package, then message
+(setq claude-code-notification-function 'claude-code--default-notification)
+
+;; Example: Use your own notification function
+(defun my-claude-notification (title message)
+  "Custom notification function for Claude Code."
+  ;; Your custom notification logic here
+  (message "[%s] %s" title message))
+(setq claude-code-notification-function 'my-claude-notification)
 ```
 
 ### Customizing Window Position

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You need to set your own key binding for the Claude Code command map. The exampl
 
 - `claude-code` (`C-c c c`) - Start Claude. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
 - `claude-code-continue` (`C-c c C`) - Start Claude and continue the previous conversation. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
+- `claude-code-resume` (`C-c c R`) - Resume a specific Claude session by ID or choose interactively. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
 - `claude-code-toggle` (`C-c c t`) - Toggle Claude window
 - `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer. With prefix arg (`C-u`), shows all Claude instances across all directories
 - `claude-code-kill` (`C-c c k`) - Kill Claude session. With prefix arg (`C-u`), kills ALL Claude instances across all directories
@@ -87,13 +88,26 @@ The command automatically detects the current mode and switches to the other:
 - If in normal terminal mode (semi-char mode), it switches to read-only mode
 - If in read-only mode (emacs mode), it switches back to normal terminal mode
 
-### Continuing Previous Conversations
+### Continuing and Resuming Conversations
 
-Use the `claude-code-continue` command (`C-c c C`) to resume where you left off in your previous Claude session. This command uses Claude's `--continue` flag to restore your conversation history.
+Claude Code provides two ways to restore previous conversations:
 
-- `claude-code-continue` - Continue previous conversation
+#### Continue Most Recent Conversation
+
+Use the `claude-code-continue` command (`C-c c C`) to resume where you left off in your most recent Claude session in the current directory. This command uses Claude's `--continue` flag.
+
+- `claude-code-continue` - Continue the most recent conversation in the current directory
 - With prefix arg (`C-u`) - Continue conversation and switch to buffer
 - With double prefix arg (`C-u C-u`) - Continue conversation in a specific directory (prompts for directory)
+
+#### Resume Specific Session
+
+Use the `claude-code-resume` command (`C-c c R`) to resume a specific past session. This command uses Claude's `--resume` flag and allows you to:
+
+- Resume any past session by selecting from an interactive list
+- Resume a specific session if you know its ID (can be passed programmatically)
+- With prefix arg (`C-u`) - Resume session and switch to buffer
+- With double prefix arg (`C-u C-u`) - Resume session in a specific directory (prompts for directory)
 
 ### Transient Menus
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ You need to set your own key binding for the Claude Code command map. The exampl
 
 ### Basic Commands
 
-- `claude-code` (`C-c c c`) - Start Claude. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), continues previous conversation. With triple prefix (`C-u C-u C-u`), prompts for the project directory
+- `claude-code` (`C-c c c`) - Start Claude. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
+- `claude-code-continue` (`C-c c C`) - Start Claude and continue the previous conversation. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
 - `claude-code-toggle` (`C-c c t`) - Toggle Claude window
 - `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer. With prefix arg (`C-u`), shows all Claude instances across all directories
 - `claude-code-kill` (`C-c c k`) - Kill Claude session. With prefix arg (`C-u`), kills ALL Claude instances across all directories
@@ -88,12 +89,11 @@ The command automatically detects the current mode and switches to the other:
 
 ### Continuing Previous Conversations
 
-The `claude-code` command supports continuing previous conversations using Claude's `--continue`
-flag:
+Use the `claude-code-continue` command (`C-c c C`) to resume where you left off in your previous Claude session. This command uses Claude's `--continue` flag to restore your conversation history.
 
-- Double prefix arg (`C-u C-u C-c c c`) - Start Claude and continue previous conversation
-
-This allows you to resume where you left off in your previous Claude session.
+- `claude-code-continue` - Continue previous conversation
+- With prefix arg (`C-u`) - Continue conversation and switch to buffer
+- With double prefix arg (`C-u C-u`) - Continue conversation in a specific directory (prompts for directory)
 
 ### Transient Menus
 
@@ -210,6 +210,11 @@ This allows you to have separate Claude conversations for different aspects of y
   ;; Your custom notification logic here
   (message "[%s] %s" title message))
 (setq claude-code-notification-function 'my-claude-notification)
+
+;; Configure kill confirmation behavior (default is t)
+;; When t, claude-code-kill prompts for confirmation before killing instances
+;; When nil, kills Claude instances without confirmation
+(setq claude-code-confirm-kill t)
 ```
 
 ### Customizing Window Position

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You need to set your own key binding for the Claude Code command map. The exampl
 - `claude-code-start-in-directory` (`C-c c d`) - Prompt for a directory and start Claude there. With prefix arg (`C-u`), switches to the Claude buffer after creating
 - `claude-code-toggle` (`C-c c t`) - Toggle Claude window
 - `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer. With prefix arg (`C-u`), shows all Claude instances across all directories
+- `claude-code-select-buffer` (`C-c c B`) - Select and switch to a Claude buffer from all running instances across all projects and directories
 - `claude-code-kill` (`C-c c k`) - Kill Claude session. With prefix arg (`C-u`), kills ALL Claude instances across all directories
 - `claude-code-send-command` (`C-c c s`) - Send command to Claude
 - `claude-code-send-command-with-context` (`C-c c x`) - Send command with current file and line context
@@ -166,6 +167,7 @@ You can run multiple Claude instances for the same directory to support differen
 - Additional instances require a name when created (e.g., "tests", "docs", "refactor")
 - When multiple instances exist for a directory, commands that interact with Claude will prompt you to select which instance to use
 - Use `C-u claude-code-switch-to-buffer` to see all Claude instances across all directories (not just the current directory)
+- Use `claude-code-select-buffer` as a dedicated command to always show all Claude instances across all directories
 
 This allows you to have separate Claude conversations for different aspects of your work within the same project, such as one instance for writing code and another for writing tests.
 

--- a/README.md
+++ b/README.md
@@ -199,14 +199,58 @@ You can control how the Claude Code window appears using Emacs' `display-buffer-
 
 This layout works best on wide screens.
 
-### Font Configuration for Better Rendering
+### Font Setup
 
-Using a font with good Unicode support helps avoid flickering while Claude Code is rendering its thinking icons. [JuliaMono](https://juliamono.netlify.app/) has excellent Unicode symbols support. To let the Claude Code buffer use Julia Mono for rendering Unicode characters while still using your default font for ASCII characters add this elisp code:
+Claude Code uses a lot of special unicode characters, and most common programming fonts don't include them all. To ensure that Claude renders special characters correctly in Emacs, you need to either use a font with really good unicode support, or set up fallback fonts for Emacs to use when your preferred font does not have a character. 
+
+### Using System Fonts as Fallbacks
+
+If you don't want to install any new fonts, you can use fonts already on your system as fallbacks. Here's a good setup for macOS, assuming your default, preferred font is "Maple Mono".  Substitute "Maple Mono" with whatever your default font is, and add this to your `init.el` file:
+
+```elisp
+;; important - tell emacs to use our fontset settings
+(setq use-default-font-for-symbols nil)
+
+;; add least preferred fonts first, most preferred last
+(set-fontset-font t 'symbol "STIX Two Math" nil 'prepend)
+(set-fontset-font t 'symbol "Zapf Dingbats" nil 'prepend)
+(set-fontset-font t 'symbol "Menlo" nil 'prepend)
+
+;; add your default, preferred font last
+(set-fontset-font t 'symbol "Maple Mono" nil 'prepend)
+```
+
+The configuration on Linux or Windows will depend on the fonts available on your system. To test if
+your system has a certain font, evaluate this expression:
+
+```elisp
+(find-font (font-spec :family "DejaVu Sans Mono"))
+```
+
+On Linux it might look like this:
+
+```elisp
+(setq use-default-font-for-symbols nil)
+(set-fontset-font t 'symbol "DejaVu Sans Mono" nil 'prepend)
+
+;; your preferred, default font:
+(set-fontset-font t 'symbol "Maple Mono" nil 'prepend)
+```
+
+### Using JuliaMono as Fallback
+
+A cross-platform approach is to install a fixed-width font with really good unicode symbols support. 
+[JuliaMono](https://juliamono.netlify.app/) has excellent Unicode symbols support. To let the Claude Code buffer use Julia Mono for rendering Unicode characters while still using your default font for ASCII characters add this elisp code:
 
 ```elisp
 (setq use-default-font-for-symbols nil)
 (set-fontset-font t 'unicode (font-spec :family "JuliaMono"))
+
+;; your preferred, default font:
+(set-fontset-font t 'symbol "Maple Mono" nil 'prepend)
 ```
+
+### Using a Custom Claude Code Font
 
 If instead you want to use a particular font just for the Claude Code REPL but use a different font
 everywhere else you can customize the `claude-code-repl-face`:
@@ -216,7 +260,7 @@ everywhere else you can customize the `claude-code-repl-face`:
    '(claude-code-repl-face ((t (:family "JuliaMono")))))
 ```
 
-#### Using Your 
+(If you set the Claude Code font to "JuliaMono", you can skip all the fontset fallback configurations above.)
 
 ### Reducing Flickering on Window Configuration Changes
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You need to set your own key binding for the Claude Code command map. The exampl
 - `claude-code` (`C-c c c`) - Start Claude. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
 - `claude-code-continue` (`C-c c C`) - Start Claude and continue the previous conversation. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
 - `claude-code-resume` (`C-c c R`) - Resume a specific Claude session by ID or choose interactively. With prefix arg (`C-u`), switches to the Claude buffer after creating. With double prefix (`C-u C-u`), prompts for the project directory
+- `claude-code-start-in-directory` (`C-c c d`) - Prompt for a directory and start Claude there. With prefix arg (`C-u`), switches to the Claude buffer after creating
 - `claude-code-toggle` (`C-c c t`) - Toggle Claude window
 - `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer. With prefix arg (`C-u`), shows all Claude instances across all directories
 - `claude-code-kill` (`C-c c k`) - Kill Claude session. With prefix arg (`C-u`), kills ALL Claude instances across all directories

--- a/claude-code.el
+++ b/claude-code.el
@@ -870,6 +870,9 @@ Returns a string with the errors or a message if no errors found."
     ;; Inherit parent eat keymap
     (set-keymap-parent map (current-local-map))
 
+    ;; C-g for escape
+    (define-key map (kbd "C-g") "")
+
     ;; Configure key bindings based on user preference
     (pcase claude-code-newline-keybinding-style
       ('default
@@ -1212,10 +1215,6 @@ Use `claude-code-exit-read-only-mode' to switch back to normal mode."
 
    ;; avoid double-cursor effect
    (eat--set-cursor nil :invisible)
-
-   (let ((cursor-pos (claude-code--get-cursor-position)))
-     (when cursor-pos
-       (goto-char cursor-pos)))
    (message "Claude read-only mode enabled")))
 
 ;;;###autoload

--- a/claude-code.el
+++ b/claude-code.el
@@ -724,6 +724,13 @@ With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt f
       (when claude-code-enable-notifications
         (eval '(setf (eat-term-parameter eat-terminal 'ring-bell-function) #'claude-code--notify)))
 
+      ;; Disable vertical scroll bar in claude buffer
+      (setq-local vertical-scroll-bar nil)
+
+      ;; Disable window fringes in claude buffer
+      (setq left-fringe-width 0)
+      (setq right-fringe-width 0)
+
       ;; fix wonky initial terminal layout that happens sometimes if we show the buffer before claude is ready
       (sleep-for claude-code-startup-delay)
       
@@ -732,7 +739,14 @@ With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt f
 
       ;; run start hooks and show the claude buffer
       (run-hooks 'claude-code-start-hook)
-      (display-buffer buffer))
+
+      ;; Display buffer. Set window parameters here, as they can get overriden if set earlier when display-buffer is called.
+      ;; Claude provides a litte space on the right but not on the left, so add a 1 column left margin and a 0 right margin.
+      ;; Turn off frignes in the claude buffer.
+      (display-buffer buffer '(window-parameters . ((left-margin-width . 0)
+                                                    (right-margin-width . 0)
+                                                    (left-fringe-width . 0)
+                                                    (right-fringe-width . 0)))))
     (when switch-after
       (switch-to-buffer buffer))))
 

--- a/claude-code.el
+++ b/claude-code.el
@@ -722,7 +722,6 @@ With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt f
 
       ;; Add notification handler if notifications are enabledd
       (when claude-code-enable-notifications
-        ;; (setq-local eat--bell #'claude-code--notify)
         (eval '(setf (eat-term-parameter eat-terminal 'ring-bell-function) #'claude-code--notify)))
 
       ;; fix wonky initial terminal layout that happens sometimes if we show the buffer before claude is ready

--- a/claude-code.el
+++ b/claude-code.el
@@ -161,7 +161,7 @@ This controls how the return key and its modifiers behave in Claude buffers:
   :type 'boolean
   :group 'claude-code)
 
-(defcustom claude-code-notification-function 'claude-code--default-notification
+(defcustom claude-code-notification-function 'claude-code-default-notification
   "Function to call for notifications.
 
 The function is called with two arguments:
@@ -677,9 +677,9 @@ With triple prefix ARG (\\[universal-argument] \\[universal-argument] \\[univers
       ;; Add window configuration change hook to keep buffer scrolled to bottom
       (add-hook 'window-configuration-change-hook #'claude-code--on-window-configuration-change nil t)
 
-      ;; Add notification handler when notifications are enabled
+      ;; Add notification handler if notifications are enabledd
       (when claude-code-enable-notifications
-        (setf (eat-term-parameter eat-terminal 'ring-bell-function) #'claude-code--notify))
+        (setq-local eat--bell #'claude-code--notify))
 
       ;; fix wonky initial terminal layout that happens sometimes if we show the buffer before claude is ready
       (sleep-for claude-code-startup-delay)
@@ -775,7 +775,7 @@ Returns a string with the errors or a message if no errors found."
                                              (lambda ()
                                                (invert-face 'mode-line))))))))
 
-(defun claude-code--default-notification (title message)
+(defun claude-code-default-notification (title message)
   "Default notification function that displays a message and pulses the modeline.
 
 TITLE is the notification title.
@@ -783,7 +783,8 @@ MESSAGE is the notification body."
   ;; Display the message
   (message "%s: %s" title message)
   ;; Pulse the modeline for visual feedback
-  (claude-code--pulse-modeline))
+  (claude-code--pulse-modeline)
+  (message "%s: %s" title message))
 
 (defun claude-code--notify (_terminal)
   "Notify the user that Claude has finished and is awaiting input.

--- a/claude-code.el
+++ b/claude-code.el
@@ -728,11 +728,8 @@ Returns a string with the errors or a message if no errors found."
 (defun claude-code--setup-claude-buffer-keymap ()
   "Set up the local keymap for Claude Code buffers."
   (let ((map (make-sparse-keymap)))
-    ;; Inherit all eat functionality by setting parent keymap
+    ;; Inherit parent eat keymap
     (set-keymap-parent map (current-local-map))
-
-    ;; make single ESC work in EAT claude buffer
-    (define-key map (kbd "ESC") "")
 
     ;; bind C-g to ESC
     (define-key map (kbd "C-g") "")

--- a/claude-code.el
+++ b/claude-code.el
@@ -731,9 +731,6 @@ Returns a string with the errors or a message if no errors found."
     ;; Inherit parent eat keymap
     (set-keymap-parent map (current-local-map))
 
-    ;; bind C-g to ESC
-    (define-key map (kbd "C-g") "")
-
     ;; Configure key bindings based on user preference
     (pcase claude-code-newline-keybinding-style
       ('default

--- a/claude-code.el
+++ b/claude-code.el
@@ -28,7 +28,7 @@
 (declare-function eat-term-display-beginning "eat" (terminal))
 (declare-function eat-term-live-p "eat" (terminal))
 
-;;;; Customization options
+;;;; Customization optionsy
 (defgroup claude-code nil
   "Claude AI interface for Emacs."
   :group 'tools)
@@ -1056,6 +1056,14 @@ TERMINAL is the eat terminal parameter (not used)."
              "Claude Ready"
              "Waiting for your response")))
 
+(defun claude-code--get-cursor-position ()
+  "Get the cursor position in Claude Code's input box."
+  (save-excursion
+    (goto-char (point-max))
+    (let ((match (re-search-backward "[^[:space:]][[:space:]]+│$" nil t)))
+      (when match
+        (+ match 1)))))
+
 ;;;; Interactive Commands
 
 ;;;###autoload
@@ -1305,10 +1313,16 @@ enter Claude commands.
 Use `claude-code-exit-read-only-mode' to switch back to normal mode."
   (interactive)
   (claude-code--with-buffer
-    (eat-emacs-mode)
-    (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
-    (eat--set-cursor nil :invisible)
-    (message "Claude read-only mode enabled")))
+   (eat-emacs-mode)
+   (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
+
+   ;; avoid double-cursor effect
+   (eat--set-cursor nil :invisible)
+
+   (let ((cursor-pos (claude-code--get-cursor-position)))
+     (when cursor-pos
+       (goto-char cursor-pos)))
+   (message "Claude read-only mode enabled")))
 
 ;;;###autoload
 (defun claude-code-exit-read-only-mode ()

--- a/claude-code.el
+++ b/claude-code.el
@@ -213,6 +213,7 @@ for each directory across multiple invocations.")
     (define-key map "b" 'claude-code-switch-to-buffer)
     (define-key map "c" 'claude-code)
     (define-key map "C" 'claude-code-continue)
+    (define-key map "R" 'claude-code-resume)
     (define-key map "e" 'claude-code-fix-error-at-point)
     (define-key map "k" 'claude-code-kill)
     (define-key map "m" 'claude-code-transient)
@@ -238,6 +239,7 @@ for each directory across multiple invocations.")
   ["Claude Commands"
    ["Manage Claude" ("c" "Start Claude" claude-code)
     ("C" "Continue conversation" claude-code-continue)
+    ("R" "Resume session" claude-code-resume)
     ("t" "Toggle claude window" claude-code-toggle)
     ("b" "Switch to Claude buffer" claude-code-switch-to-buffer)
     ("k" "Kill Claude" claude-code-kill)
@@ -770,6 +772,124 @@ With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt f
          (trimmed-buffer-name (string-trim-right (string-trim buffer-name "\\*") "\\*"))
          (buffer (get-buffer-create buffer-name))
          (program-switches (append claude-code-program-switches '("--continue"))))
+    ;; Start the eat process
+    (with-current-buffer buffer
+      (cd dir)
+      (setq-local eat-term-name claude-code-term-name)
+
+      ;; Turn off shell integration, as we don't need it for Claude
+      (setq-local eat-enable-directory-tracking t
+                  eat-enable-shell-command-history nil
+                  eat-enable-shell-prompt-annotation nil)
+      
+      ;; Conditionally disable scrollback truncation
+      (when claude-code-never-truncate-claude-buffer
+        (setq-local eat-term-scrollback-size nil))
+
+      (let ((process-adaptive-read-buffering nil))
+        (condition-case nil
+            (apply #'eat-make trimmed-buffer-name claude-code-program nil program-switches)
+          (error
+           (error "error starting claude")
+           (signal 'claude-start-error "error starting claude"))))
+
+      ;; Setup our custom key bindings
+      (claude-code--setup-claude-buffer-keymap)
+
+      ;; Set eat repl faces to inherit from claude-code-repl-face
+      (claude-code--setup-repl-faces)
+
+      ;; Add advice to only nottify claude on window width changes, to avoid uncessary flickering
+      (advice-add 'eat--adjust-process-window-size :around #'claude-code--eat-adjust-process-window-size-advice)
+
+      ;; Set our custom synchronize scroll function
+      (setq-local eat--synchronize-scroll-function #'claude-code--synchronize-scroll)
+
+      ;; Add window configuration change hook to keep buffer scrolled to bottom
+      (add-hook 'window-configuration-change-hook #'claude-code--on-window-configuration-change nil t)
+
+      ;; Add notification handler if notifications are enabledd
+      (when claude-code-enable-notifications
+        ;; (setq-local eat--bell #'claude-code--notify)
+        (setf (eat-term-parameter eat-terminal 'ring-bell-function) #'claude-code--notify))
+
+      ;; fix wonky initial terminal layout that happens sometimes if we show the buffer before claude is ready
+      (sleep-for claude-code-startup-delay)
+
+      ;; Add cleanup hook to remove directory mappings when buffer is killed
+      (add-hook 'kill-buffer-hook #'claude-code--cleanup-directory-mapping nil t)
+
+      ;; run start hooks and show the claude buffer
+      (run-hooks 'claude-code-start-hook)
+      (display-buffer buffer))
+    (when switch-after
+      (switch-to-buffer buffer))))
+
+;;;###autoload
+(defun claude-code-resume (&optional session-id arg)
+  "Resume a specific Claude session by ID or choose interactively.
+
+This command starts Claude with the --resume flag to resume a
+specific past session. If SESSION-ID is provided, resumes that
+specific session. Otherwise, Claude will present an interactive
+list of past sessions to choose from.
+
+If current buffer belongs to a project start Claude in the project's
+root directory. Otherwise start in the directory of the current buffer
+file, or the current value of `default-directory' if no project and no
+buffer file.
+
+With prefix ARG (\\[universal-argument]), switch to buffer after creating.
+With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt for the project directory."
+  (interactive "P")
+
+  ;; When called interactively, the session-id will be nil and arg will contain prefix arg
+  (when (and (called-interactively-p 'any) session-id)
+    ;; session-id contains the prefix arg when called interactively
+    (setq arg session-id
+          session-id nil))
+
+  ;; Forward declare variables to avoid compilation warnings
+  (require 'eat)
+
+  (let* ((dir (if (equal arg '(16))  ; Double prefix
+                  (read-directory-name "Project directory: ")
+                (claude-code--directory)))
+         (abbreviated-dir (abbreviate-file-name dir))
+         (switch-after (equal arg '(4))) ; Single prefix
+         (default-directory dir)
+         ;; Check for existing Claude instances in this directory
+         (existing-buffers (claude-code--find-claude-buffers-for-directory dir))
+         ;; Determine instance name
+         (existing-instance-names (mapcar (lambda (buf)
+                                            (or (claude-code--extract-instance-name-from-buffer-name
+                                                 (buffer-name buf))
+                                                "default"))
+                                          existing-buffers))
+         (instance-name (if existing-buffers
+                            (let ((proposed-name ""))
+                              (while (or (string-empty-p proposed-name)
+                                         (member proposed-name existing-instance-names))
+                                (setq proposed-name
+                                      (read-string (format "Instances already running for %s (existing: %s), new instance name: "
+                                                           abbreviated-dir
+                                                           (mapconcat #'identity existing-instance-names ", "))
+                                                   nil nil proposed-name))
+                                (cond
+                                 ((string-empty-p proposed-name)
+                                  (message "Instance name cannot be empty. Please enter a name.")
+                                  (sit-for 1))
+                                 ((member proposed-name existing-instance-names)
+                                  (message "Instance name '%s' already exists. Please choose a different name." proposed-name)
+                                  (sit-for 1))))
+                              proposed-name)
+                          "default"))
+         (buffer-name (claude-code--buffer-name instance-name))
+         (trimmed-buffer-name (string-trim-right (string-trim buffer-name "\\*") "\\*"))
+         (buffer (get-buffer-create buffer-name))
+         (program-switches (if session-id
+                               (append claude-code-program-switches (list "--resume" session-id))
+                             (append claude-code-program-switches '("--resume")))))
     ;; Start the eat process
     (with-current-buffer buffer
       (cd dir)

--- a/claude-code.el
+++ b/claude-code.el
@@ -16,6 +16,7 @@
 (require 'transient)
 (require 'project)
 (require 'cl-lib)
+(eval-when-compile (require 'eat nil t))
 
 ;; Declare external variables and functions from eat package
 (defvar eat--semi-char-mode)
@@ -27,6 +28,7 @@
 (declare-function eat-term-display-cursor "eat" (terminal))
 (declare-function eat-term-display-beginning "eat" (terminal))
 (declare-function eat-term-live-p "eat" (terminal))
+(declare-function eat-term-parameter "eat" (terminal parameter) t)
 
 ;;;; Customization optionsy
 (defgroup claude-code nil
@@ -623,7 +625,6 @@ EXTRA-SWITCHES is a list of additional command-line switches to pass to Claude.
 With single prefix ARG (\\[universal-argument]), switch to buffer after creating.
 With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt for the project directory."
   (require 'eat)
-
   (let* ((dir (if (equal arg '(16))  ; Double prefix
                   (read-directory-name "Project directory: ")
                 (claude-code--directory)))
@@ -701,7 +702,7 @@ With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt f
       ;; Add notification handler if notifications are enabledd
       (when claude-code-enable-notifications
         ;; (setq-local eat--bell #'claude-code--notify)
-        (setf (eat-term-parameter eat-terminal 'ring-bell-function) #'claude-code--notify))
+        (eval '(setf (eat-term-parameter eat-terminal 'ring-bell-function) #'claude-code--notify)))
 
       ;; fix wonky initial terminal layout that happens sometimes if we show the buffer before claude is ready
       (sleep-for claude-code-startup-delay)

--- a/claude-code.el
+++ b/claude-code.el
@@ -214,6 +214,7 @@ for each directory across multiple invocations.")
     (define-key map "c" 'claude-code)
     (define-key map "C" 'claude-code-continue)
     (define-key map "R" 'claude-code-resume)
+    (define-key map "d" 'claude-code-start-in-directory)
     (define-key map "e" 'claude-code-fix-error-at-point)
     (define-key map "k" 'claude-code-kill)
     (define-key map "m" 'claude-code-transient)
@@ -240,6 +241,7 @@ for each directory across multiple invocations.")
    ["Manage Claude" ("c" "Start Claude" claude-code)
     ("C" "Continue conversation" claude-code-continue)
     ("R" "Resume session" claude-code-resume)
+    ("d" "Start in directory" claude-code-start-in-directory)
     ("t" "Toggle claude window" claude-code-toggle)
     ("b" "Switch to Claude buffer" claude-code-switch-to-buffer)
     ("k" "Kill Claude" claude-code-kill)
@@ -715,6 +717,22 @@ With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt f
       (display-buffer buffer))
     (when switch-after
       (switch-to-buffer buffer))))
+
+;;;###autoload
+(defun claude-code-start-in-directory (&optional arg)
+  "Prompt for a directory and start Claude there.
+
+This is a convenience command equivalent to using `claude-code` with
+double prefix arg (\\[universal-argument] \\[universal-argument]).
+
+With prefix ARG (\\[universal-argument]), switch to buffer after creating."
+  (interactive "P")
+  ;; Always prompt for directory (like double prefix)
+  ;; If user gave us a prefix arg, also switch to buffer after creating
+  (let ((dir (read-directory-name "Project directory: ")))
+    ;; We need to temporarily override claude-code--directory to return our chosen dir
+    (cl-letf (((symbol-function 'claude-code--directory) (lambda () dir)))
+      (claude-code (when arg '(4))))))
 
 ;;;###autoload
 (defun claude-code-continue (&optional arg)

--- a/claude-code.el
+++ b/claude-code.el
@@ -242,16 +242,21 @@ for each directory across multiple invocations.")
 (transient-define-prefix claude-code-transient ()
   "Claude command menu."
   ["Claude Commands"
-   ["Manage Claude" ("c" "Start Claude" claude-code)
+   ["Start/Stop Claude"
+    ("c" "Start Claude" claude-code)
     ("C" "Continue conversation" claude-code-continue)
     ("R" "Resume session" claude-code-resume)
     ("i" "New instance" claude-code-new-instance)
     ("d" "Start in directory" claude-code-start-in-directory)
+    ("k" "Kill Claude" claude-code-kill)
+    ]
+   ["Manage Claude"
     ("t" "Toggle claude window" claude-code-toggle)
     ("b" "Switch to Claude buffer" claude-code-switch-to-buffer)
     ("B" "Select from all Claude buffers" claude-code-select-buffer)
-    ("k" "Kill Claude" claude-code-kill)
-    ("z" "Toggle read-only mode" claude-code-toggle-read-only-mode)]
+    ("z" "Toggle read-only mode" claude-code-toggle-read-only-mode)
+    ("TAB" "Cycle Claude mode" claude-code-cycle-mode :transient t)
+    ]
    ["Send Commands to Claude" ("s" "Send command" claude-code-send-command)
     ("x" "Send command with context" claude-code-send-command-with-context)
     ("r" "Send region or buffer" claude-code-send-region)
@@ -263,7 +268,7 @@ for each directory across multiple invocations.")
     ("1" "Send \"1\"" claude-code-send-1)
     ("2" "Send \"2\"" claude-code-send-2)
     ("3" "Send \"3\"" claude-code-send-3)
-    ("TAB" "Cycle Claude mode" claude-code-cycle-mode :transient t)]])
+    ]])
 
 ;;;###autoload (autoload 'claude-code-slash-commands "claude-code" nil t)
 (transient-define-prefix claude-code-slash-commands ()

--- a/claude-code.el
+++ b/claude-code.el
@@ -255,8 +255,7 @@ for each directory across multiple invocations.")
     ("1" "Send \"1\"" claude-code-send-1)
     ("2" "Send \"2\"" claude-code-send-2)
     ("3" "Send \"3\"" claude-code-send-3)
-    ("TAB" "Cycle Claude mode" claude-code-cycle-mode)]])
-
+    ("TAB" "Cycle Claude mode" claude-code-cycle-mode :transient t)]])
 
 ;;;###autoload (autoload 'claude-code-slash-commands "claude-code" nil t)
 (transient-define-prefix claude-code-slash-commands ()


### PR DESCRIPTION
## Summary
- New instance creation and selection commands
- Kill all instances command  
- Resume specific sessions
- C-g escape key binding
- Organized transient menu

- New `claude-code-newline-keybinding-style` customization variable to configure how return and modifier keys behave in Claude buffers
  - `'default` (default): M-return inserts newline, RET sends message
  - `'newline-on-return`: RET inserts newline, M-return sends message
  - `'newline-on-shift-return`: RET sends message, S-return inserts newline
  - `'super-return-to-send`: RET inserts newline, s-return sends message
- Single ESC key now works as expected in Claude buffers for canceling operations
- C-g can be used as an alternative to ESC for canceling in Claude buffers
- New `claude-code-confirm-kill` customization variable to control kill confirmation prompts
  - When `t` (default), prompts for confirmation before killing Claude instances
  - When `nil`, kills Claude instances without confirmation
- New `claude-code-continue` command to explicitly continue previous conversations
  - Bound to `C-c c C` in the command map
  - Supports same prefix arguments as `claude-code` command
- New `claude-code-resume` command to resume specific past sessions
  - Bound to `C-c c R` in the command map
  - Allows resuming any past session from an interactive list
  - Can programmatically resume a specific session by ID
  - Supports same prefix arguments as `claude-code` command
- New `claude-code-start-in-directory` command for convenience
  - Bound to `C-c c d` in the command map
  - Always prompts for directory (equivalent to `C-u C-u claude-code`)
  - With prefix arg, switches to buffer after creating
- New `claude-code-new-instance` command to create a new Claude instance with a custom name
  - Bound to `C-c c i` in the command map
  - Always prompts for instance name (unlike `claude-code` which uses "default" for the first instance)
  - Supports same prefix arguments as `claude-code` command
- New `claude-code-select-buffer` command to select from all Claude instances
  - Bound to `C-c c B` in the command map
  - Shows all Claude instances across all projects and directories
  - Provides a dedicated command for global instance selection (similar to `C-u claude-code-switch-to-buffer`)
- New `claude-code-kill-all` command to kill all Claude instances
  - Bound to `C-c c K` in the command map
  - Kills all Claude instances across all projects and directories
  - Provides dedicated functionality previously available via `C-u claude-code-kill`

### Changed

- Renamed internal variable from `claude-code-key-binding-style` to `claude-code-newline-keybinding-style` for clarity
- Simplified `claude-code` command prefix arguments:
  - Single prefix (`C-u`) now switches to buffer after creating
  - Double prefix (`C-u C-u`) now prompts for project directory
  - Removed support for continuing conversations (use `claude-code-continue` instead)
- `claude-code-kill` no longer accepts prefix arguments
  - Use the new `claude-code-kill-all` command to kill all instances

## Refactoring
- Extracted common startup logic
- Simplified keymap setup
- Reduced code duplication