### PR TITLE
Add multi-instance command station with org mode task tracking and workspace integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 - **Continue Conversations** - Resume previous sessions or fork to earlier points
 - **Read-Only Mode** - Toggle to select and copy text with normal Emacs commands and keybindings
 - **Mode Cycling** - Quick switch between default, auto-accept edits, and plan modes
-- **Desktop Notifications** - Get notified when Claude finishes processing
+- **Enhanced Notifications** - Clickable notifications with optional Org mode task tracking
 - **Terminal Choice** - Works with both eat and vterm backends
 - **Fully Customizable** - Configure keybindings, notifications, and display preferences
 
@@ -218,7 +218,65 @@ You can change this behavior by customizing `claude-code-newline-keybinding-styl
 
 ## Desktop Notifications
 
-claude-code.el notifies you when Claude finishes processing and is waiting for input. By default, it displays a message in the minibuffer and pulses the modeline for visual feedback.
+claude-code.el notifies you when Claude finishes processing and is waiting for input. By default, it displays a message in the minibuffer and pulses the modeline for visual feedback. Enhanced notification features include clickable buffer links and optional Org mode task tracking.
+
+### Enhanced Notification System
+
+The enhanced notification system provides clickable notifications that allow you to jump directly to Claude buffers:
+
+- When Claude finishes a task, a notification buffer appears with a clickable button
+- Click the button to instantly switch to the Claude buffer
+- Notifications auto-dismiss after 10 seconds to reduce clutter
+- Works with both task completion and session termination events
+
+### Org Mode Task Tracking
+
+claude-code.el includes an optional Org mode integration that automatically tracks completed Claude tasks in a persistent log:
+
+#### Features
+
+- **Persistent Task Log**: All completed Claude tasks are saved to `~/.claude/taskmaster.org`
+- **Automatic Timestamps**: Each task entry includes completion timestamp
+- **Clickable Buffer Links**: Elisp links in org entries allow instant buffer switching
+- **Smart Display**: Popup notifications only appear when Claude buffer is not currently visible (taskmaster.org entries are always created)
+- **Dual Event Tracking**: Captures both task completion and session stop events
+
+#### Setup
+
+To enable Org mode notifications, add this to your configuration:
+
+```elisp
+;; Load the org notifications system
+(require 'claude-code-org-notifications)
+
+;; Automatically configure Claude Code hooks for notifications
+(claude-code-setup-hooks)
+```
+
+This will:
+1. Create the necessary directory structure (`~/.claude/`)
+2. Generate or update your Claude Code settings.json with notification hooks
+3. Enable automatic task logging to the taskmaster.org file
+
+#### Manual Hook Configuration
+
+If you prefer to manually configure hooks or already have a settings.json file, you can call:
+
+```elisp
+(claude-code-setup-hooks)
+```
+
+This function intelligently merges notification hooks with your existing configuration.
+
+#### Hook Context Variables
+
+Claude Code automatically exports the `CLAUDE_BUFFER_NAME` environment variable to the shell session, making it available to hooks and child processes. This allows hooks to:
+
+- Identify which Claude buffer triggered the notification
+- Pass buffer context to external notification handlers
+- Enable buffer-specific actions in custom scripts
+
+The environment variable contains the full buffer name (e.g., `*claude:/path/to/project:default*`) and is automatically set when Claude starts.
 
 ### macOS Native Notifications
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 - **Read-Only Mode** - Toggle to select and copy text with normal Emacs commands and keybindings
 - **Mode Cycling** - Quick switch between default, auto-accept edits, and plan modes
 - **Enhanced Notifications** - Clickable notifications with optional Org mode task tracking
+- **Workspace Integration** - Navigate to workspaces containing Claude buffers with perspective.el support
 - **Terminal Choice** - Works with both eat and vterm backends
 - **Fully Customizable** - Configure keybindings, notifications, and display preferences
 
@@ -26,6 +27,7 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 - [Claude Code CLI](https://github.com/anthropics/claude-code) installed and configured
 - Required: transient (0.7.5+)
 - Optional: eat (0.9.2+) for eat backend, vterm for vterm backend
+- Optional: perspective.el for workspace navigation features
 
 ### Using builtin use-package (Emacs 30+)
 
@@ -120,6 +122,8 @@ in this code".
 
 Use the `claude-code-send-region` (`C-c c r`) command to send the selected region to Claude, or the entire buffer if no region is selected. This command is useful for writing a prompt in a regular Emacs buffer and sending it to Claude. With a single prefix arg (`C-u C-c c r`) it will prompt for extra context before sending the region to Claude.
 
+You can also send files directly to Claude using `claude-code-send-file` to send any file by path, or `claude-code-send-buffer-file` (`C-c c o`) to send the file associated with the current buffer. The `claude-code-send-buffer-file` command supports prefix arguments similar to `claude-code-send-region` - with a single prefix arg it prompts for instructions, and with double prefix it also switches to the Claude buffer.
+
 If you put your cursor over a flymake or flycheck error, you can ask Claude to fix it via `claude-code-fix-error-at-point` (`C-c c e`).
 
 To show and hide the Claude buffer use `claude-code-toggle` (`C-c c t`).  To jump to the Claude buffer use `claude-code-switch-to-buffer` (`C-c c b`). This will open the buffer if hidden.
@@ -201,6 +205,8 @@ You can change this behavior by customizing `claude-code-newline-keybinding-styl
 - `claude-code-send-command` (`C-c c s`) - Send command to Claude. With prefix arg (`C-u`), switches to the Claude buffer after sending
 - `claude-code-send-command-with-context` (`C-c c x`) - Send command with current file and line context. With prefix arg (`C-u`), switches to the Claude buffer after sending
 - `claude-code-send-region` (`C-c c r`) - Send the current region or buffer to Claude. With prefix arg (`C-u`), prompts for instructions to add to the text. With double prefix (`C-u C-u`), adds instructions and switches to Claude buffer
+- `claude-code-send-file` - Send a specified file to Claude. Prompts for file path
+- `claude-code-send-buffer-file` (`C-c c o`) - Send the file associated with current buffer to Claude. With prefix arg (`C-u`), prompts for instructions to add to the file. With double prefix (`C-u C-u`), adds instructions and switches to Claude buffer
 - `claude-code-fix-error-at-point` (`C-c c e`) - Ask Claude to fix the error at the current point (works with flycheck, flymake, and any system that implements help-at-pt). With prefix arg (`C-u`), switches to the Claude buffer after sending
 - `claude-code-fork` (`C-c c f`) - Fork conversation (jump to previous conversation by sending escape-escape to Claude)
 - `claude-code-slash-commands` (`C-c c /`) - Access Claude slash commands menu
@@ -223,7 +229,73 @@ You can change this behavior by customizing `claude-code-newline-keybinding-styl
 
 ## Desktop Notifications
 
-claude-code.el notifies you when Claude finishes processing and is waiting for input. By default, it displays a message in the minibuffer and pulses the modeline for visual feedback. Enhanced notification features include clickable buffer links and optional Org mode task tracking.
+claude-code.el notifies you when Claude finishes processing and is waiting for input. By default, it displays a message in the minibuffer and pulses the modeline for visual feedback.
+
+### macOS Native Notifications
+
+To use macOS native notifications with sound, add this to your configuration:
+
+```elisp
+(defun my-claude-notify (title message)
+  "Display a macOS notification with sound."
+  (call-process "osascript" nil nil nil
+                "-e" (format "display notification \"%s\" with title \"%s\" sound name \"Glass\""
+                             message title)))
+
+(setq claude-code-notification-function #'my-claude-notify)
+```
+
+This will display a system notification with a "Glass" sound effect when Claude is ready. You can change the sound name to any system sound (e.g., "Ping", "Hero", "Morse", etc.) or remove the `sound name` part for silent notifications.
+
+### Linux Native Notifications
+
+For Linux desktop notifications, you can use `notify-send` (GNOME/Unity) or `kdialog` (KDE):
+
+```elisp
+;; For GNOME/Unity desktops
+(defun my-claude-notify (title message)
+  "Display a Linux notification using notify-send."
+  (if (executable-find "notify-send")
+      (call-process "notify-send" nil nil nil title message)
+    (message "%s: %s" title message)))
+
+(setq claude-code-notification-function #'my-claude-notify)
+```
+
+To add sound on Linux:
+
+```elisp
+(defun my-claude-notify-with-sound (title message)
+  "Display a Linux notification with sound."
+  (when (executable-find "notify-send")
+    (call-process "notify-send" nil nil nil title message))
+  ;; Play sound if paplay is available
+  (when (executable-find "paplay")
+    (call-process "paplay" nil nil nil "/usr/share/sounds/freedesktop/stereo/message.oga")))
+
+(setq claude-code-notification-function #'my-claude-notify-with-sound)
+```
+
+### Windows Native Notifications
+
+For Windows, you can use PowerShell to create toast notifications:
+
+```elisp
+(defun my-claude-notify (title message)
+  "Display a Windows notification using PowerShell."
+  (call-process "powershell" nil nil nil
+                "-NoProfile" "-Command"
+                (concat "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null; "
+                        "$template = '<toast><visual><binding template=\"ToastGeneric\"><text>" title "</text><text>" message "</text></binding></visual></toast>'; "
+                        "$xml = New-Object Windows.Data.Xml.Dom.XmlDocument; "
+                        "$xml.LoadXml($template); "
+                        "$toast = [Windows.UI.Notifications.ToastNotification]::new($xml); "
+                        "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Emacs').Show($toast)")))
+
+(setq claude-code-notification-function #'my-claude-notify)
+```
+
+*Note: Linux and Windows examples are untested. Feedback and improvements are welcome!*
 
 ### Enhanced Notification System
 
@@ -294,72 +366,6 @@ The notification system includes workspace support that integrates with project-
 - **Keyboard Commands**: Use `C-c c w` to go to the most recent workspace or `C-c c W` to go there and clear the org entry
 
 When Claude completes a task, the workspace information is automatically extracted from the buffer name and included in both the org mode log entries and notification popups. The "Open & Clear" button and `C-c c W` command allow you to quickly navigate to a workspace and mark the corresponding org entry as DONE, helping you maintain a clean task queue.
-
-### macOS Native Notifications
-
-To use macOS native notifications with sound, add this to your configuration:
-
-```elisp
-(defun my-claude-notify (title message)
-  "Display a macOS notification with sound."
-  (call-process "osascript" nil nil nil
-                "-e" (format "display notification \"%s\" with title \"%s\" sound name \"Glass\""
-                             message title)))
-
-(setq claude-code-notification-function #'my-claude-notify)
-```
-
-This will display a system notification with a "Glass" sound effect when Claude is ready. You can change the sound name to any system sound (e.g., "Ping", "Hero", "Morse", etc.) or remove the `sound name` part for silent notifications.
-
-### Linux Native Notifications
-
-For Linux desktop notifications, you can use `notify-send` (GNOME/Unity) or `kdialog` (KDE):
-
-```elisp
-;; For GNOME/Unity desktops
-(defun my-claude-notify (title message)
-  "Display a Linux notification using notify-send."
-  (if (executable-find "notify-send")
-      (call-process "notify-send" nil nil nil title message)
-    (message "%s: %s" title message)))
-
-(setq claude-code-notification-function #'my-claude-notify)
-```
-
-To add sound on Linux:
-
-```elisp
-(defun my-claude-notify-with-sound (title message)
-  "Display a Linux notification with sound."
-  (when (executable-find "notify-send")
-    (call-process "notify-send" nil nil nil title message))
-  ;; Play sound if paplay is available
-  (when (executable-find "paplay")
-    (call-process "paplay" nil nil nil "/usr/share/sounds/freedesktop/stereo/message.oga")))
-
-(setq claude-code-notification-function #'my-claude-notify-with-sound)
-```
-
-### Windows Native Notifications
-
-For Windows, you can use PowerShell to create toast notifications:
-
-```elisp
-(defun my-claude-notify (title message)
-  "Display a Windows notification using PowerShell."
-  (call-process "powershell" nil nil nil
-                "-NoProfile" "-Command"
-                (concat "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null; "
-                        "$template = '<toast><visual><binding template=\"ToastGeneric\"><text>" title "</text><text>" message "</text></binding></visual></toast>'; "
-                        "$xml = New-Object Windows.Data.Xml.Dom.XmlDocument; "
-                        "$xml.LoadXml($template); "
-                        "$toast = [Windows.UI.Notifications.ToastNotification]::new($xml); "
-                        "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Emacs').Show($toast)")))
-
-(setq claude-code-notification-function #'my-claude-notify)
-```
-
-*Note: Linux and Windows examples are untested. Feedback and improvements are welcome!*
 
 ## Tips and Tricks
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ You can change this behavior by customizing `claude-code-newline-keybinding-styl
 - `claude-code-send-2` (`C-c c 2`) - Send "2" to Claude (useful for selecting the second option when Claude presents a numbered menu)
 - `claude-code-send-3` (`C-c c 3`) - Send "3" to Claude (useful for selecting the third option when Claude presents a numbered menu)
 
+#### Workspace Navigation Commands
+
+- `claude-code-goto-recent-workspace` (`C-c c w`) - Go to the most recent workspace from the taskmaster org file
+- `claude-code-goto-recent-workspace-and-clear` (`C-c c W`) - Go to the most recent workspace and mark the org entry as DONE
+
 ## Desktop Notifications
 
 claude-code.el notifies you when Claude finishes processing and is waiting for input. By default, it displays a message in the minibuffer and pulses the modeline for visual feedback. Enhanced notification features include clickable buffer links and optional Org mode task tracking.
@@ -277,6 +282,18 @@ Claude Code automatically exports the `CLAUDE_BUFFER_NAME` environment variable 
 - Enable buffer-specific actions in custom scripts
 
 The environment variable contains the full buffer name (e.g., `*claude:/path/to/project:default*`) and is automatically set when Claude starts.
+
+#### Workspace Integration
+
+The notification system includes workspace support that integrates with project-based workflows:
+
+- **Automatic Workspace Detection**: Claude automatically detects your current project/workspace directory when starting
+- **Clickable Workspace Links**: Org mode entries include clickable workspace links that switch to the workspace directory
+- **Workspace Buttons**: Notification popups include "Open Workspace" and "Open & Clear" buttons for quick workspace switching
+- **Multiple Instance Support**: Works seamlessly with multiple Claude instances in the same workspace
+- **Keyboard Commands**: Use `C-c c w` to go to the most recent workspace or `C-c c W` to go there and clear the org entry
+
+When Claude completes a task, the workspace information is automatically extracted from the buffer name and included in both the org mode log entries and notification popups. The "Open & Clear" button and `C-c c W` command allow you to quickly navigate to a workspace and mark the corresponding org entry as DONE, helping you maintain a clean task queue.
 
 ### macOS Native Notifications
 

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -73,13 +73,12 @@ specified Claude buffer and adds an entry to the taskmaster org file.
 This is intended to be called from Claude Code hooks via emacsclient."
   (let* (;; Handle backwards compatibility: if message looks like a buffer name, swap parameters
          (is-buffer-name (and message (string-match-p "^\\*claude:" message)))
-         (actual-message (if is-buffer-name 
+         (actual-message (if is-buffer-name
                              (or buffer-name-override "Task completed")
                            message))
          (actual-buffer-name (if is-buffer-name
                                  message
-                               (or buffer-name-override
-                                   (getenv "CLAUDE_BUFFER_NAME"))))
+                               buffer-name-override))
          (notification-buffer "*Claude Code Notification*")
          (target-buffer (when actual-buffer-name (get-buffer actual-buffer-name))))
     
@@ -134,34 +133,39 @@ This is intended to be called from Claude Code hooks via emacsclient."
          (emacsclient-cmd (executable-find "emacsclient"))
          (hooks-config `((hooks . ((Notification . [((matcher . "")
                                                      (hooks . [((type . "command")
-                                                                (command . ,(format "%s --eval \"(claude-code-handle-notification \\\"Claude task completed\\\" \\\"$CLAUDE_BUFFER_NAME\\\")\""
-                                                                                    emacsclient-cmd)))]))])))))
+                                                                (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(claude-code-handle-notification \\\"Claude task completed\\\" \\\"$BUFFER\\\")\""
+                                                                                    emacsclient-cmd)))]))])
+
+                                   (Stop . [((matcher . "")
+                                             (hooks . [((type . "command")
+                                                        (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(claude-code-handle-notification \\\"Claude session stopped\\\" \\\"$BUFFER\\\")\""
+                                                                            emacsclient-cmd)))]))])))))
          (existing-config (when (file-exists-p settings-file)
-                            (condition-case err
-                                (json-read-file settings-file)
-                              (error
-                               (message "Warning: Could not parse existing settings.json: %s" (error-message-string err))
-                               nil))))
-         (new-config (if existing-config
-                         (let ((config-alist (if (hash-table-p existing-config)
-                                                 (claude-code--hash-table-to-alist existing-config)
-                                               existing-config)))
-                           (claude-code--merge-hooks-config config-alist hooks-config))
-                       hooks-config)))
+                     (condition-case err
+                         (json-read-file settings-file)
+                       (error
+                        (message "Warning: Could not parse existing settings.json: %s" (error-message-string err))
+                        nil))))
+  (new-config (if existing-config
+                  (let ((config-alist (if (hash-table-p existing-config)
+                                          (claude-code--hash-table-to-alist existing-config)
+                                        existing-config)))
+                    (claude-code--merge-hooks-config config-alist hooks-config))
+                hooks-config)))
 
-    (unless emacsclient-cmd
-      (error "emacsclient not found in PATH. Please ensure Emacs server is properly installed"))
+(unless emacsclient-cmd
+  (error "emacsclient not found in PATH. Please ensure Emacs server is properly installed"))
 
-    ;; Ensure Claude directory exists
-    (unless (file-directory-p claude-dir)
-      (make-directory claude-dir t))
+;; Ensure Claude directory exists
+(unless (file-directory-p claude-dir)
+  (make-directory claude-dir t))
 
-    ;; Write updated config with pretty formatting
-    (with-temp-file settings-file
-      (let ((json-encoding-pretty-print t))
-        (insert (json-encode new-config))))
+;; Write updated config with pretty formatting
+(with-temp-file settings-file
+  (let ((json-encoding-pretty-print t))
+    (insert (json-encode new-config))))
 
-    (message "Claude Code notification hooks added to %s" settings-file)))
+(message "Claude Code notification hooks added to %s" settings-file)))
 
 (defun claude-code--hash-table-to-alist (hash-table)
   "Convert HASH-TABLE to an alist."

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -78,13 +78,13 @@ MESSAGE is the notification message to include in the TODO entry."
       (insert "\n")
       (write-region (point-min) (point-max) claude-code-taskmaster-org-file))))
 
-(defun claude-code--get-most-recent-workspace ()
-  "Get the most recent workspace from the taskmaster org file."
+(defun claude-code--get-most-recent-buffer ()
+  "Get the most recent Claude buffer name from the taskmaster org file."
   (when (file-exists-p claude-code-taskmaster-org-file)
     (with-temp-buffer
       (insert-file-contents claude-code-taskmaster-org-file)
       (goto-char (point-max))
-      (when (re-search-backward "Workspace: .*elisp:(let ((default-directory \"\([^\"]+\)\"))" nil t)
+      (when (re-search-backward "Buffer: \\[\\[elisp:(switch-to-buffer \"\\([^\"]+\\)\")\\]\\[" nil t)
         (match-string 1)))))
 
 (defun claude-code--find-workspace-for-buffer (buffer-name)
@@ -280,35 +280,19 @@ This is intended to be called from Claude Code hooks via emacsclient."
 (defun claude-code-goto-recent-workspace ()
   "Go to the most recent workspace from the taskmaster org file."
   (interactive)
-  (if-let ((workspace-dir (claude-code--get-most-recent-workspace)))
-      ;; Try to find a Claude buffer in the workspace directory to use for detection
-      (let ((claude-buffers (cl-loop for buf in (buffer-list)
-                                     when (and (buffer-name buf)
-                                               (string-match-p "^\\*claude:" (buffer-name buf))
-                                               (string-match-p (regexp-quote workspace-dir) (buffer-name buf)))
-                                     return (buffer-name buf))))
-        (if claude-buffers
-            (claude-code--switch-to-workspace-for-buffer claude-buffers)
-          (message "No Claude buffer found for workspace directory: %s" workspace-dir)))
+  (if-let ((buffer-name (claude-code--get-most-recent-buffer)))
+      (claude-code--switch-to-workspace-for-buffer buffer-name)
     (message "No recent workspace found in taskmaster.org")))
 
 ;;;###autoload
 (defun claude-code-goto-recent-workspace-and-clear ()
   "Go to the most recent workspace and clear the org entry."
   (interactive)
-  (if-let ((workspace-dir (claude-code--get-most-recent-workspace)))
-      ;; Try to find a Claude buffer in the workspace directory to use for detection
-      (let ((claude-buffers (cl-loop for buf in (buffer-list)
-                                     when (and (buffer-name buf)
-                                               (string-match-p "^\\*claude:" (buffer-name buf))
-                                               (string-match-p (regexp-quote workspace-dir) (buffer-name buf)))
-                                     return (buffer-name buf))))
-        (if claude-buffers
-            (progn
-              (claude-code--switch-to-workspace-for-buffer claude-buffers)
-              (claude-code--clear-most-recent-org-entry)
-              (message "Switched to workspace and cleared org entry for buffer: %s" claude-buffers))
-          (message "No Claude buffer found for workspace directory: %s" workspace-dir)))
+  (if-let ((buffer-name (claude-code--get-most-recent-buffer)))
+      (progn
+        (claude-code--switch-to-workspace-for-buffer buffer-name)
+        (claude-code--clear-most-recent-org-entry)
+        (message "Switched to workspace and cleared org entry for buffer: %s" buffer-name))
     (message "No recent workspace found in taskmaster.org")))
 
 ;;;; Integration

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -69,6 +69,25 @@ MESSAGE is the notification message to include in the TODO entry."
       (insert "\n")
       (write-region (point-min) (point-max) claude-code-taskmaster-org-file))))
 
+(defun claude-code--get-most-recent-workspace ()
+  "Get the most recent workspace from the taskmaster org file."
+  (when (file-exists-p claude-code-taskmaster-org-file)
+    (with-temp-buffer
+      (insert-file-contents claude-code-taskmaster-org-file)
+      (goto-char (point-max))
+      (when (re-search-backward "Workspace: .*elisp:(let ((default-directory \"\([^\"]+\)\"))" nil t)
+        (match-string 1)))))
+
+(defun claude-code--clear-most-recent-org-entry ()
+  "Clear (mark as DONE) the most recent TODO entry in the taskmaster org file."
+  (when (file-exists-p claude-code-taskmaster-org-file)
+    (with-temp-buffer
+      (insert-file-contents claude-code-taskmaster-org-file)
+      (goto-char (point-max))
+      (when (re-search-backward "^\* TODO Claude task completed" nil t)
+        (replace-match "* DONE Claude task completed")
+        (write-region (point-min) (point-max) claude-code-taskmaster-org-file)))))
+
 ;;;; Enhanced notification system
 
 ;;;###autoload
@@ -76,60 +95,61 @@ MESSAGE is the notification message to include in the TODO entry."
   "Handle notification with clickable link to Claude buffer and org queue entry.
 
 MESSAGE is the notification message to display and log.
-BUFFER-NAME-OVERRIDE allows specifying a different buffer name than the
-environment variable.
+BUFFER-NAME-OVERRIDE is the name of the Claude buffer.
 
 Creates a notification buffer with a clickable button to switch to the
 specified Claude buffer and adds an entry to the taskmaster org file.
 This is intended to be called from Claude Code hooks via emacsclient."
-  (let* (;; Handle backwards compatibility: if message looks like a buffer name, swap parameters
-         (is-buffer-name (and message (string-match-p "^\\*claude:" message)))
-         (actual-message (if is-buffer-name
-                             (or buffer-name-override "Task completed")
-                           message))
-         (actual-buffer-name (if is-buffer-name
-                                 message
-                               buffer-name-override))
-         (notification-buffer "*Claude Code Notification*")
-         (target-buffer (when actual-buffer-name (get-buffer actual-buffer-name)))
-         (workspace-dir (claude-code--get-workspace-from-buffer-name actual-buffer-name)))
+  (let* ((notification-buffer "*Claude Code Notification*")
+         (target-buffer (when buffer-name-override (get-buffer buffer-name-override)))
+         (workspace-dir (claude-code--get-workspace-from-buffer-name buffer-name-override)))
     
     ;; Add entry to org file
-    (claude-code--add-org-todo-entry actual-buffer-name actual-message)
+    (claude-code--add-org-todo-entry buffer-name-override message)
     
-    ;; Only show popup if the Claude buffer is not currently visible
-    (unless (and target-buffer (get-buffer-window target-buffer))
+    ;; Only show popup if the Claude buffer is not currently visible or focused
+    (unless (and target-buffer 
+                 (or (get-buffer-window target-buffer)
+                     (eq (current-buffer) target-buffer)))
       ;; Create and display notification buffer
       (with-current-buffer (get-buffer-create notification-buffer)
         (let ((inhibit-read-only t))
           (erase-buffer)
-          (insert (format "Claude notification: %s\n" (or actual-message "Task completed")))
-          (insert (format "Buffer: %s\n\n" (or actual-buffer-name "unknown buffer")))
+          (insert (format "Claude notification: %s\n" (or message "Task completed")))
+          (insert (format "Buffer: %s\n\n" (or buffer-name-override "unknown buffer")))
           
           (if (and target-buffer (buffer-live-p target-buffer))
               (insert-button "Switch to Claude buffer"
-                             'action (lambda (_button)
-                                       (when (buffer-live-p target-buffer)
-                                         (switch-to-buffer target-buffer)
-                                         (kill-buffer notification-buffer)))
-                             'help-echo (format "Click to switch to %s" actual-buffer-name))
-            (insert (format "Buffer '%s' not found or no longer exists." (or actual-buffer-name "unknown"))))
+                             'action `(lambda (_button)
+                                        (when (buffer-live-p ,target-buffer)
+                                          (switch-to-buffer ,target-buffer)
+                                          (kill-buffer ,notification-buffer)))
+                             'help-echo (format "Click to switch to %s" buffer-name-override))
+            (insert (format "Buffer '%s' not found or no longer exists." (or buffer-name-override "unknown"))))
           
           (insert "\n")
           (when workspace-dir
             (insert-button "Open Workspace"
-                           'action (lambda (_button)
-                                     (let ((default-directory workspace-dir))
-                                       (+workspace/switch-to-0))
-                                     (kill-buffer notification-buffer))
+                           'action `(lambda (_button)
+                                      (let ((default-directory ,workspace-dir))
+                                        (+workspace/switch-to-0))
+                                      (kill-buffer ,notification-buffer))
                            'help-echo (format "Click to switch to workspace: %s" workspace-dir))
+            (insert "   ")
+            (insert-button "Open & Clear"
+                           'action `(lambda (_button)
+                                      (let ((default-directory ,workspace-dir))
+                                        (+workspace/switch-to-0))
+                                      (claude-code--clear-most-recent-org-entry)
+                                      (kill-buffer ,notification-buffer))
+                           'help-echo (format "Click to switch to workspace and clear org entry: %s" workspace-dir))
             (insert "\n"))
           
           (insert "\n")
           (insert-button "View Task Queue"
-                         'action (lambda (_button)
-                                   (find-file claude-code-taskmaster-org-file)
-                                   (kill-buffer notification-buffer))
+                         'action `(lambda (_button)
+                                    (find-file ,claude-code-taskmaster-org-file)
+                                    (kill-buffer ,notification-buffer))
                          'help-echo "Click to view the org mode task queue")
           
           (goto-char (point-min))
@@ -155,12 +175,12 @@ This is intended to be called from Claude Code hooks via emacsclient."
          (emacsclient-cmd (executable-find "emacsclient"))
          (hooks-config `((hooks . ((Notification . [((matcher . "")
                                                      (hooks . [((type . "command")
-                                                                (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(claude-code-handle-notification \\\"Claude task completed\\\" \\\"$BUFFER\\\")\""
+                                                                (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(require 'claude-code-org-notifications) (claude-code-handle-notification \\\"Claude task completed\\\" \\\"$BUFFER\\\")\""
                                                                                     emacsclient-cmd)))]))])
 
                                    (Stop . [((matcher . "")
                                              (hooks . [((type . "command")
-                                                        (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(claude-code-handle-notification \\\"Claude session stopped\\\" \\\"$BUFFER\\\")\""
+                                                        (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(require 'claude-code-org-notifications) (claude-code-handle-notification \\\"Claude session stopped\\\" \\\"$BUFFER\\\")\""
                                                                             emacsclient-cmd)))]))])))))
          (existing-config (when (file-exists-p settings-file)
                      (condition-case err
@@ -207,6 +227,30 @@ This is intended to be called from Claude Code hooks via emacsclient."
       ;; No hooks section, add it
       (push hooks-entry config-copy))
     config-copy))
+
+;;;; Workspace Navigation Commands
+
+;;;###autoload
+(defun claude-code-goto-recent-workspace ()
+  "Go to the most recent workspace from the taskmaster org file."
+  (interactive)
+  (if-let ((workspace-dir (claude-code--get-most-recent-workspace)))
+      (let ((default-directory workspace-dir))
+        (+workspace/switch-to-0)
+        (message "Switched to workspace: %s" workspace-dir))
+    (message "No recent workspace found in taskmaster.org")))
+
+;;;###autoload
+(defun claude-code-goto-recent-workspace-and-clear ()
+  "Go to the most recent workspace and clear the org entry."
+  (interactive)
+  (if-let ((workspace-dir (claude-code--get-most-recent-workspace)))
+      (progn
+        (let ((default-directory workspace-dir))
+          (+workspace/switch-to-0))
+        (claude-code--clear-most-recent-org-entry)
+        (message "Switched to workspace and cleared org entry: %s" workspace-dir))
+    (message "No recent workspace found in taskmaster.org")))
 
 ;;;; Integration
 

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -37,16 +37,26 @@ with timestamps and links back to the original Claude buffers."
   "Format current time as an org mode timestamp."
   (format-time-string "[%Y-%m-%d %a %H:%M]"))
 
+(defun claude-code--get-workspace-from-buffer-name (buffer-name)
+  "Extract workspace directory from Claude BUFFER-NAME.
+For example, *claude:/path/to/project/* returns /path/to/project/."
+  (when (and buffer-name (string-match "^\\*claude:\\([^:]+\\)\\(?::\\([^*]+\\)\\)?\\*$" buffer-name))
+    (match-string 1 buffer-name)))
+
 (defun claude-code--add-org-todo-entry (buffer-name message)
   "Add a TODO entry to the taskmaster org file.
 
 BUFFER-NAME is the name of the Claude buffer that completed a task.
 MESSAGE is the notification message to include in the TODO entry."
   (claude-code--ensure-claude-directory)
-  (let ((timestamp (claude-code--format-org-timestamp))
-        (buffer-link (if buffer-name
-                         (format "[[elisp:(switch-to-buffer \"%s\")][%s]]" buffer-name buffer-name)
-                       "Unknown buffer")))
+  (let* ((timestamp (claude-code--format-org-timestamp))
+         (buffer-link (if buffer-name
+                          (format "[[elisp:(switch-to-buffer \"%s\")][%s]]" buffer-name buffer-name)
+                        "Unknown buffer"))
+         (workspace-dir (claude-code--get-workspace-from-buffer-name buffer-name))
+         (workspace-link (if workspace-dir
+                             (format "[[elisp:(let ((default-directory \"%s\")) (+workspace/switch-to-0))][%s]]" workspace-dir (file-name-nondirectory (directory-file-name workspace-dir)))
+                           "Unknown workspace")))
     (with-temp-buffer
       (when (file-exists-p claude-code-taskmaster-org-file)
         (insert-file-contents claude-code-taskmaster-org-file))
@@ -55,6 +65,7 @@ MESSAGE is the notification message to include in the TODO entry."
       (insert (format "* TODO Claude task completed %s\n" timestamp))
       (insert (format "  Message: %s\n" (or message "Task completed")))
       (insert (format "  Buffer: %s\n" buffer-link))
+      (insert (format "  Workspace: %s\n" workspace-link))
       (insert "\n")
       (write-region (point-min) (point-max) claude-code-taskmaster-org-file))))
 
@@ -80,7 +91,8 @@ This is intended to be called from Claude Code hooks via emacsclient."
                                  message
                                buffer-name-override))
          (notification-buffer "*Claude Code Notification*")
-         (target-buffer (when actual-buffer-name (get-buffer actual-buffer-name))))
+         (target-buffer (when actual-buffer-name (get-buffer actual-buffer-name)))
+         (workspace-dir (claude-code--get-workspace-from-buffer-name actual-buffer-name)))
     
     ;; Add entry to org file
     (claude-code--add-org-todo-entry actual-buffer-name actual-message)
@@ -103,7 +115,17 @@ This is intended to be called from Claude Code hooks via emacsclient."
                              'help-echo (format "Click to switch to %s" actual-buffer-name))
             (insert (format "Buffer '%s' not found or no longer exists." (or actual-buffer-name "unknown"))))
           
-          (insert "\n\n")
+          (insert "\n")
+          (when workspace-dir
+            (insert-button "Open Workspace"
+                           'action (lambda (_button)
+                                     (let ((default-directory workspace-dir))
+                                       (+workspace/switch-to-0))
+                                     (kill-buffer notification-buffer))
+                           'help-echo (format "Click to switch to workspace: %s" workspace-dir))
+            (insert "\n"))
+          
+          (insert "\n")
           (insert-button "View Task Queue"
                          'action (lambda (_button)
                                    (find-file claude-code-taskmaster-org-file)

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -75,6 +75,7 @@ MESSAGE is the notification message to include in the TODO entry."
       (insert (format "  Message: %s\n" (or message "Task completed")))
       (insert (format "  Buffer: %s\n" buffer-link))
       (insert (format "  Workspace: %s\n" workspace-link))
+      (insert (format "  Actions: [[elisp:(claude-code--clear-current-org-entry)][Clear]] | [[elisp:(claude-code--switch-to-workspace-for-buffer \"%s\")][Go to Workspace]]\n" buffer-name))
       (insert "\n")
       (write-region (point-min) (point-max) claude-code-taskmaster-org-file))))
 
@@ -116,6 +117,19 @@ MESSAGE is the notification message to include in the TODO entry."
       (when (re-search-backward "^\* TODO Claude task completed" nil t)
         (replace-match "* DONE Claude task completed")
         (write-region (point-min) (point-max) claude-code-taskmaster-org-file)))))
+
+(defun claude-code--clear-current-org-entry ()
+  "Clear (mark as DONE) the current TODO entry under point in the taskmaster org file."
+  (interactive)
+  (when (and (buffer-file-name)
+             (string= (file-name-nondirectory (buffer-file-name)) "taskmaster.org"))
+    ;; We're in the taskmaster.org file, mark current entry as DONE
+    (save-excursion
+      (org-back-to-heading t)
+      (when (looking-at "^\* TODO Claude task completed")
+        (replace-match "* DONE Claude task completed")
+        (save-buffer)
+        (message "Marked current entry as DONE")))))
 
 ;;;; Enhanced notification system
 

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -1,0 +1,196 @@
+;;; claude-code-org-notifications.el --- Org mode notification queue for Claude Code -*- lexical-binding: t; -*-
+
+;; Author: Claude AI
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "30.0") (claude-code "0.2.0"))
+;; Keywords: tools, ai, org
+
+;;; Commentary:
+;; This package extends claude-code.el with org mode notification queue functionality.
+;; It provides persistent task tracking in ~/.claude/taskmaster.org with timestamps
+;; and clickable buffer links, plus smart popup notifications that only appear when
+;; the Claude buffer isn't currently visible.
+
+;;; Code:
+
+(require 'json)
+
+;;;; Customization
+
+(defcustom claude-code-taskmaster-org-file (expand-file-name "~/.claude/taskmaster.org")
+  "Path to the org mode file for storing Claude task notifications.
+
+This file will contain a queue of completed Claude tasks as TODO entries
+with timestamps and links back to the original Claude buffers."
+  :type 'file
+  :group 'claude-code)
+
+;;;; Org mode integration functions
+
+(defun claude-code--ensure-claude-directory ()
+  "Ensure the Claude directory exists for storing taskmaster.org."
+  (let ((claude-dir (file-name-directory claude-code-taskmaster-org-file)))
+    (unless (file-directory-p claude-dir)
+      (make-directory claude-dir t))))
+
+(defun claude-code--format-org-timestamp ()
+  "Format current time as an org mode timestamp."
+  (format-time-string "[%Y-%m-%d %a %H:%M]"))
+
+(defun claude-code--add-org-todo-entry (buffer-name message)
+  "Add a TODO entry to the taskmaster org file.
+
+BUFFER-NAME is the name of the Claude buffer that completed a task.
+MESSAGE is the notification message to include in the TODO entry."
+  (claude-code--ensure-claude-directory)
+  (let ((timestamp (claude-code--format-org-timestamp))
+        (buffer-link (if buffer-name
+                         (format "[[elisp:(switch-to-buffer \"%s\")][%s]]" buffer-name buffer-name)
+                       "Unknown buffer")))
+    (with-temp-buffer
+      (when (file-exists-p claude-code-taskmaster-org-file)
+        (insert-file-contents claude-code-taskmaster-org-file))
+      (goto-char (point-max))
+      (unless (bolp) (insert "\n"))
+      (insert (format "* TODO Claude task completed %s\n" timestamp))
+      (insert (format "  Message: %s\n" (or message "Task completed")))
+      (insert (format "  Buffer: %s\n" buffer-link))
+      (insert "\n")
+      (write-region (point-min) (point-max) claude-code-taskmaster-org-file))))
+
+;;;; Enhanced notification system
+
+;;;###autoload
+(defun claude-code-handle-notification (message &optional buffer-name-override)
+  "Handle notification with clickable link to Claude buffer and org queue entry.
+
+MESSAGE is the notification message to display and log.
+BUFFER-NAME-OVERRIDE allows specifying a different buffer name than the
+environment variable.
+
+Creates a notification buffer with a clickable button to switch to the
+specified Claude buffer and adds an entry to the taskmaster org file.
+This is intended to be called from Claude Code hooks via emacsclient."
+  (let* (;; Handle backwards compatibility: if message looks like a buffer name, swap parameters
+         (is-buffer-name (and message (string-match-p "^\\*claude:" message)))
+         (actual-message (if is-buffer-name 
+                             (or buffer-name-override "Task completed")
+                           message))
+         (actual-buffer-name (if is-buffer-name
+                                 message
+                               (or buffer-name-override
+                                   (getenv "CLAUDE_BUFFER_NAME"))))
+         (notification-buffer "*Claude Code Notification*")
+         (target-buffer (when actual-buffer-name (get-buffer actual-buffer-name))))
+    
+    ;; Add entry to org file
+    (claude-code--add-org-todo-entry actual-buffer-name actual-message)
+    
+    ;; Only show popup if the Claude buffer is not currently visible
+    (unless (and target-buffer (get-buffer-window target-buffer))
+      ;; Create and display notification buffer
+      (with-current-buffer (get-buffer-create notification-buffer)
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (insert (format "Claude notification: %s\n" (or actual-message "Task completed")))
+          (insert (format "Buffer: %s\n\n" (or actual-buffer-name "unknown buffer")))
+          
+          (if (and target-buffer (buffer-live-p target-buffer))
+              (insert-button "Switch to Claude buffer"
+                             'action (lambda (_button)
+                                       (when (buffer-live-p target-buffer)
+                                         (switch-to-buffer target-buffer)
+                                         (kill-buffer notification-buffer)))
+                             'help-echo (format "Click to switch to %s" actual-buffer-name))
+            (insert (format "Buffer '%s' not found or no longer exists." (or actual-buffer-name "unknown"))))
+          
+          (insert "\n\n")
+          (insert-button "View Task Queue"
+                         'action (lambda (_button)
+                                   (find-file claude-code-taskmaster-org-file)
+                                   (kill-buffer notification-buffer))
+                         'help-echo "Click to view the org mode task queue")
+          
+          (goto-char (point-min))
+          (setq buffer-read-only t))
+        
+        ;; Display the notification buffer
+        (display-buffer notification-buffer)))))
+
+;;;###autoload
+(defun claude-code-test-notification ()
+  "Test the notification system interactively."
+  (interactive)
+  (claude-code-handle-notification "Test notification message" (buffer-name)))
+
+;;;; Settings.json configuration helper
+
+;;;###autoload
+(defun claude-code-setup-hooks ()
+  "Add or update Claude Code notification hooks in ~/.claude/settings.json."
+  (interactive)
+  (let* ((claude-dir (expand-file-name "~/.claude"))
+         (settings-file (expand-file-name "settings.json" claude-dir))
+         (emacsclient-cmd (executable-find "emacsclient"))
+         (hooks-config `((hooks . ((Notification . [((matcher . "")
+                                                     (hooks . [((type . "command")
+                                                                (command . ,(format "%s --eval \"(claude-code-handle-notification \\\"Claude task completed\\\")\""
+                                                                                    emacsclient-cmd)))]))])))))
+         (existing-config (when (file-exists-p settings-file)
+                            (condition-case err
+                                (json-read-file settings-file)
+                              (error
+                               (message "Warning: Could not parse existing settings.json: %s" (error-message-string err))
+                               nil))))
+         (new-config (if existing-config
+                         (let ((config-alist (if (hash-table-p existing-config)
+                                                 (claude-code--hash-table-to-alist existing-config)
+                                               existing-config)))
+                           (claude-code--merge-hooks-config config-alist hooks-config))
+                       hooks-config)))
+
+    (unless emacsclient-cmd
+      (error "emacsclient not found in PATH. Please ensure Emacs server is properly installed"))
+
+    ;; Ensure Claude directory exists
+    (unless (file-directory-p claude-dir)
+      (make-directory claude-dir t))
+
+    ;; Write updated config
+    (with-temp-file settings-file
+      (insert (json-encode new-config)))
+
+    (message "Claude Code notification hooks added to %s" settings-file)))
+
+(defun claude-code--hash-table-to-alist (hash-table)
+  "Convert HASH-TABLE to an alist."
+  (let (result)
+    (maphash (lambda (key value)
+               (push (cons key value) result))
+             hash-table)
+    (nreverse result)))
+
+(defun claude-code--merge-hooks-config (existing-config hooks-config)
+  "Merge HOOKS-CONFIG into EXISTING-CONFIG, preserving other settings."
+  (let ((config-copy (copy-alist existing-config))
+        (hooks-entry (assoc 'hooks hooks-config)))
+    (if (assoc 'hooks config-copy)
+        ;; Hooks section exists, merge it
+        (setcdr (assoc 'hooks config-copy) (cdr hooks-entry))
+      ;; No hooks section, add it
+      (push hooks-entry config-copy))
+    config-copy))
+
+;;;; Integration
+
+;; Check if Doom Emacs is available and configure popup rule
+(when (and (boundp 'doom-version) (fboundp 'set-popup-rule!))
+  (set-popup-rule! "^\\*Claude Code Notification\\*$"
+    :side 'bottom
+    :size 0.3
+    :select nil
+    :quit t))
+
+(provide 'claude-code-org-notifications)
+
+;;; claude-code-org-notifications.el ends here

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -75,7 +75,7 @@ MESSAGE is the notification message to include in the TODO entry."
       (insert (format "  Message: %s\n" (or message "Task completed")))
       (insert (format "  Buffer: %s\n" buffer-link))
       (insert (format "  Workspace: %s\n" workspace-link))
-      (insert (format "  Actions: [[elisp:(claude-code--clear-current-org-entry)][Clear]] | [[elisp:(claude-code--switch-to-workspace-for-buffer \"%s\")][Go to Workspace]]\n" buffer-name))
+      (insert (format "  Actions: [[elisp:(claude-code--switch-to-workspace-for-buffer \"%s\")][Go to Workspace]] | [[elisp:(claude-code--clear-current-org-entry-and-switch \"%s\")][Clear and Go to Workspace]]\n" buffer-name buffer-name))
       (insert "\n")
       (write-region (point-min) (point-max) claude-code-taskmaster-org-file))))
 
@@ -118,18 +118,24 @@ MESSAGE is the notification message to include in the TODO entry."
         (replace-match "* DONE Claude task completed")
         (write-region (point-min) (point-max) claude-code-taskmaster-org-file)))))
 
-(defun claude-code--clear-current-org-entry ()
-  "Clear (mark as DONE) the current TODO entry under point in the taskmaster org file."
+(defun claude-code--clear-current-org-entry-and-switch (buffer-name)
+  "Delete the current TODO entry and switch to workspace for BUFFER-NAME."
   (interactive)
   (when (and (buffer-file-name)
              (string= (file-name-nondirectory (buffer-file-name)) "taskmaster.org"))
-    ;; We're in the taskmaster.org file, mark current entry as DONE
+    ;; We're in the taskmaster.org file, delete current entry
     (save-excursion
       (org-back-to-heading t)
       (when (looking-at "^\* TODO Claude task completed")
-        (replace-match "* DONE Claude task completed")
+        ;; Delete the entire entry (from heading to next heading or end of buffer)
+        (let ((start (point)))
+          (if (outline-next-heading)
+              (delete-region start (point))
+            (delete-region start (point-max))))
         (save-buffer)
-        (message "Marked current entry as DONE")))))
+        (message "Deleted entry and switching to workspace...")
+        ;; Switch to workspace
+        (claude-code--switch-to-workspace-for-buffer buffer-name)))))
 
 ;;;; Enhanced notification system
 

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -22,6 +22,13 @@
 (declare-function persp-switch "persp-mode")
 (declare-function persp-buffers "persp-mode")
 
+;; Constants
+(defconst claude-code-notification-buffer-name "*Claude Code Notification*"
+  "Name of the notification buffer.")
+
+(defconst claude-code-org-todo-pattern "^\* TODO Claude task completed"
+  "Pattern to match Claude task entries in org file.")
+
 ;;;; Customization
 
 (defcustom claude-code-taskmaster-org-file (expand-file-name "~/.claude/taskmaster.org")
@@ -121,7 +128,7 @@ MESSAGE is the notification message to include in the TODO entry."
     (with-temp-buffer
       (insert-file-contents claude-code-taskmaster-org-file)
       (goto-char (point-max))
-      (when (re-search-backward "^\* TODO Claude task completed" nil t)
+      (when (re-search-backward claude-code-org-todo-pattern nil t)
         (replace-match "* DONE Claude task completed")
         (write-region (point-min) (point-max) claude-code-taskmaster-org-file)))))
 
@@ -133,7 +140,7 @@ MESSAGE is the notification message to include in the TODO entry."
     ;; We're in the taskmaster.org file, delete current entry
     (save-excursion
       (org-back-to-heading t)
-      (when (looking-at "^\* TODO Claude task completed")
+      (when (looking-at claude-code-org-todo-pattern)
         ;; Delete the entire entry (from heading to next heading or end of buffer)
         (let ((start (point)))
           (if (outline-next-heading)
@@ -198,11 +205,11 @@ BUFFER-NAME-OVERRIDE is the name of the Claude buffer.
 Creates a notification buffer with a clickable button to switch to the
 specified Claude buffer and adds an entry to the taskmaster org file.
 This is intended to be called from Claude Code hooks via emacsclient."
-  (let* ((notification-buffer "*Claude Code Notification*")
+  (let* ((notification-buffer claude-code-notification-buffer-name)
          (target-buffer (when buffer-name-override (get-buffer buffer-name-override)))
          (has-workspace (and buffer-name-override 
-                            (claude-code--get-workspace-from-buffer-name buffer-name-override))))
-    
+                             (claude-code--get-workspace-from-buffer-name buffer-name-override))))
+
     ;; Add entry to org file
     (claude-code--add-org-todo-entry buffer-name-override message)
     
@@ -263,7 +270,7 @@ This is intended to be called from Claude Code hooks via emacsclient."
         ;; Auto-dismiss timer
         (run-with-timer 10 nil `(lambda ()
                                   (when (buffer-live-p (get-buffer ,notification-buffer))
-                                    (claude-code--dismiss-and-kill-buffer ,notification-buffer)))))))
+                                    (claude-code--dismiss-and-kill-buffer ,notification-buffer))))))))
 
 ;;;###autoload
 (defun claude-code-test-notification ()

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -16,13 +16,11 @@
 (require 'json)
 (require 'cl-lib)
 
-;; Declare functions from Doom Emacs workspaces
-(declare-function +workspace-list-names "workspaces")
-(declare-function +workspace-get "workspaces")
-(declare-function +workspace/switch-to "workspaces")
-(declare-function +workspace/switch-to-0 "workspaces")
-(declare-function +workspace-buffer-list "workspaces")
-(declare-function persp-parameter "persp-mode")
+;; Declare functions from perspective.el
+(declare-function persp-names "persp-mode")
+(declare-function persp-get-by-name "persp-mode")
+(declare-function persp-switch "persp-mode")
+(declare-function persp-buffers "persp-mode")
 
 ;;;; Customization
 
@@ -88,30 +86,30 @@ MESSAGE is the notification message to include in the TODO entry."
         (match-string 1)))))
 
 (defun claude-code--find-workspace-for-buffer (buffer-name)
-  "Find the workspace that contains the specified BUFFER-NAME."
-  (when (and (boundp 'doom-version) (fboundp '+workspace-list-names))
+  "Find the perspective that contains the specified BUFFER-NAME."
+  (when (featurep 'persp-mode)
     (let ((target-buffer (get-buffer buffer-name)))
       (when target-buffer
-        (cl-loop for workspace-name in (+workspace-list-names)
-                 for workspace = (+workspace-get workspace-name)
-                 when (and workspace
-                           (member target-buffer (+workspace-buffer-list workspace)))
-                 return workspace-name)))))
+        (cl-loop for persp-name in (persp-names)
+                 for persp = (persp-get-by-name persp-name)
+                 when (and persp
+                           (member target-buffer (persp-buffers persp)))
+                 return persp-name)))))
 
 (defun claude-code--switch-to-workspace-for-buffer (buffer-name)
-  "Switch to the workspace that contains the specified BUFFER-NAME and navigate to the buffer."
-  (if-let ((workspace-name (claude-code--find-workspace-for-buffer buffer-name)))
+  "Switch to the perspective that contains the specified BUFFER-NAME and navigate to the buffer."
+  (if-let ((persp-name (claude-code--find-workspace-for-buffer buffer-name)))
       (progn
-        (+workspace/switch-to workspace-name)
+        (persp-switch persp-name)
         (when-let ((target-buffer (get-buffer buffer-name)))
           (if-let ((window (get-buffer-window target-buffer)))
               ;; Buffer is visible, just select the window
               (select-window window)
             ;; Buffer is not visible, display it
             (switch-to-buffer target-buffer)))
-        (message "Switched to workspace: %s and navigated to buffer: %s" workspace-name buffer-name)
-        workspace-name)
-    (error "No workspace found for buffer: %s" buffer-name)))
+        (message "Switched to perspective: %s and navigated to buffer: %s" persp-name buffer-name)
+        persp-name)
+    (error "No perspective found for buffer: %s" buffer-name)))
 
 (defun claude-code--clear-most-recent-org-entry ()
   "Clear (mark as DONE) the most recent TODO entry in the taskmaster org file."
@@ -284,22 +282,22 @@ This is intended to be called from Claude Code hooks via emacsclient."
 
 ;;;###autoload
 (defun claude-code-goto-recent-workspace ()
-  "Go to the most recent workspace from the taskmaster org file."
+  "Go to the most recent perspective from the taskmaster org file."
   (interactive)
   (if-let ((buffer-name (claude-code--get-most-recent-buffer)))
       (claude-code--switch-to-workspace-for-buffer buffer-name)
-    (message "No recent workspace found in taskmaster.org")))
+    (message "No recent perspective found in taskmaster.org")))
 
 ;;;###autoload
 (defun claude-code-goto-recent-workspace-and-clear ()
-  "Go to the most recent workspace and clear the org entry."
+  "Go to the most recent perspective and clear the org entry."
   (interactive)
   (if-let ((buffer-name (claude-code--get-most-recent-buffer)))
       (progn
         (claude-code--switch-to-workspace-for-buffer buffer-name)
         (claude-code--clear-most-recent-org-entry)
-        (message "Switched to workspace and cleared org entry for buffer: %s" buffer-name))
-    (message "No recent workspace found in taskmaster.org")))
+        (message "Switched to perspective and cleared org entry for buffer: %s" buffer-name))
+    (message "No recent perspective found in taskmaster.org")))
 
 ;;;; Integration
 

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -134,7 +134,7 @@ This is intended to be called from Claude Code hooks via emacsclient."
          (emacsclient-cmd (executable-find "emacsclient"))
          (hooks-config `((hooks . ((Notification . [((matcher . "")
                                                      (hooks . [((type . "command")
-                                                                (command . ,(format "%s --eval \"(claude-code-handle-notification \\\"Claude task completed\\\")\""
+                                                                (command . ,(format "%s --eval \"(claude-code-handle-notification \\\"Claude task completed\\\" \\\"$CLAUDE_BUFFER_NAME\\\")\""
                                                                                     emacsclient-cmd)))]))])))))
          (existing-config (when (file-exists-p settings-file)
                             (condition-case err
@@ -156,9 +156,10 @@ This is intended to be called from Claude Code hooks via emacsclient."
     (unless (file-directory-p claude-dir)
       (make-directory claude-dir t))
 
-    ;; Write updated config
+    ;; Write updated config with pretty formatting
     (with-temp-file settings-file
-      (insert (json-encode new-config)))
+      (let ((json-encoding-pretty-print t))
+        (insert (json-encode new-config))))
 
     (message "Claude Code notification hooks added to %s" settings-file)))
 

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -74,7 +74,6 @@ MESSAGE is the notification message to include in the TODO entry."
       (insert (format "* TODO Claude task completed %s\n" timestamp))
       (insert (format "  Message: %s\n" (or message "Task completed")))
       (insert (format "  Buffer: %s\n" buffer-link))
-      (insert (format "  Workspace: %s\n" workspace-link))
       (insert (format "  Actions: [[elisp:(claude-code--switch-to-workspace-for-buffer \"%s\")][Go to Workspace]] | [[elisp:(claude-code--clear-current-org-entry-and-switch \"%s\")][Clear and Go to Workspace]]\n" buffer-name buffer-name))
       (insert "\n")
       (write-region (point-min) (point-max) claude-code-taskmaster-org-file))))

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -99,13 +99,14 @@ MESSAGE is the notification message to include in the TODO entry."
                  return workspace-name)))))
 
 (defun claude-code--switch-to-workspace-for-buffer (buffer-name)
-  "Switch to the workspace that contains the specified BUFFER-NAME and switch to the buffer."
+  "Switch to the workspace that contains the specified BUFFER-NAME and navigate to the buffer."
   (if-let ((workspace-name (claude-code--find-workspace-for-buffer buffer-name)))
       (progn
         (+workspace/switch-to workspace-name)
-        (when (get-buffer buffer-name)
-          (switch-to-buffer buffer-name))
-        (message "Switched to workspace: %s and buffer: %s" workspace-name buffer-name)
+        (when-let ((target-buffer (get-buffer buffer-name))
+                   (window (get-buffer-window target-buffer)))
+          (select-window window))
+        (message "Switched to workspace: %s and navigated to buffer: %s" workspace-name buffer-name)
         workspace-name)
     (error "No workspace found for buffer: %s" buffer-name)))
 

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -103,9 +103,12 @@ MESSAGE is the notification message to include in the TODO entry."
   (if-let ((workspace-name (claude-code--find-workspace-for-buffer buffer-name)))
       (progn
         (+workspace/switch-to workspace-name)
-        (when-let ((target-buffer (get-buffer buffer-name))
-                   (window (get-buffer-window target-buffer)))
-          (select-window window))
+        (when-let ((target-buffer (get-buffer buffer-name)))
+          (if-let ((window (get-buffer-window target-buffer)))
+              ;; Buffer is visible, just select the window
+              (select-window window)
+            ;; Buffer is not visible, display it
+            (switch-to-buffer target-buffer)))
         (message "Switched to workspace: %s and navigated to buffer: %s" workspace-name buffer-name)
         workspace-name)
     (error "No workspace found for buffer: %s" buffer-name)))

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -181,6 +181,11 @@ MESSAGE is the notification message to include in the TODO entry."
     (kill-buffer claude-code--notification-buffer-name)
     (claude-code--disable-notification-dismiss)))
 
+(defun claude-code--dismiss-and-kill-buffer (buffer-name)
+  "Helper to dismiss notification and kill BUFFER-NAME."
+  (claude-code--disable-notification-dismiss)
+  (kill-buffer buffer-name))
+
 ;;;; Enhanced notification system
 
 ;;;###autoload
@@ -195,7 +200,8 @@ specified Claude buffer and adds an entry to the taskmaster org file.
 This is intended to be called from Claude Code hooks via emacsclient."
   (let* ((notification-buffer "*Claude Code Notification*")
          (target-buffer (when buffer-name-override (get-buffer buffer-name-override)))
-         (workspace-dir (claude-code--get-workspace-from-buffer-name buffer-name-override)))
+         (has-workspace (and buffer-name-override 
+                            (claude-code--get-workspace-from-buffer-name buffer-name-override))))
     
     ;; Add entry to org file
     (claude-code--add-org-todo-entry buffer-name-override message)
@@ -220,26 +226,23 @@ This is intended to be called from Claude Code hooks via emacsclient."
                                           (when (and (boundp 'evil-mode) evil-mode
                                                      (string-match-p "^\\*claude:" ,buffer-name-override))
                                             (evil-insert-state))
-                                          (claude-code--disable-notification-dismiss)
-                                          (kill-buffer ,notification-buffer)))
+                                          (claude-code--dismiss-and-kill-buffer ,notification-buffer)))
                              'help-echo (format "Click to switch to %s" buffer-name-override))
             (insert (format "Buffer '%s' not found or no longer exists." (or buffer-name-override "unknown"))))
           
           (insert "\n")
-          (when workspace-dir
+          (when has-workspace
             (insert-button "Open Workspace"
                            'action `(lambda (_button)
                                       (claude-code--switch-to-workspace-for-buffer ,buffer-name-override)
-                                      (claude-code--disable-notification-dismiss)
-                                      (kill-buffer ,notification-buffer))
+                                      (claude-code--dismiss-and-kill-buffer ,notification-buffer))
                            'help-echo (format "Click to switch to workspace for buffer: %s" buffer-name-override))
             (insert "   ")
             (insert-button "Open & Clear"
                            'action `(lambda (_button)
                                       (claude-code--switch-to-workspace-for-buffer ,buffer-name-override)
                                       (claude-code--clear-most-recent-org-entry)
-                                      (claude-code--disable-notification-dismiss)
-                                      (kill-buffer ,notification-buffer))
+                                      (claude-code--dismiss-and-kill-buffer ,notification-buffer))
                            'help-echo (format "Click to switch to workspace and clear org entry for buffer: %s" buffer-name-override))
             (insert "\n"))
           
@@ -247,38 +250,20 @@ This is intended to be called from Claude Code hooks via emacsclient."
           (insert-button "View Task Queue"
                          'action `(lambda (_button)
                                     (find-file ,claude-code-taskmaster-org-file)
-                                    (claude-code--disable-notification-dismiss)
-                                    (kill-buffer ,notification-buffer))
+                                    (claude-code--dismiss-and-kill-buffer ,notification-buffer))
                          'help-echo "Click to view the org mode task queue")
           
           (goto-char (point-min))
           (setq buffer-read-only t))
         
-        ;; Display the notification buffer
-        (let ((window (display-buffer notification-buffer)))
-          ;; Set up window-specific quit behavior like Doom popups
-          (set-window-parameter window 'quit-window 
-                                `(lambda ()
-                                   (interactive)
-                                   (claude-code--disable-notification-dismiss)
-                                   (quit-window nil ,window)))
-          
-          ;; Set up the notification dismiss system
-          (claude-code--enable-notification-dismiss notification-buffer)
-          
-          ;; Add quit-window keybinding to the buffer
-          (with-current-buffer notification-buffer
-            (local-set-key (kbd "q") `(lambda () 
-                                        (interactive) 
-                                        (claude-code--disable-notification-dismiss)
-                                        (quit-window)))
-            (local-set-key (kbd "<escape>") `(lambda () 
-                                               (interactive) 
-                                               (claude-code--disable-notification-dismiss)
-                                               (quit-window))))
-          
-
-          window)))))
+        ;; Display the notification buffer and set up dismissal
+        (display-buffer notification-buffer)
+        (claude-code--enable-notification-dismiss notification-buffer)
+        
+        ;; Auto-dismiss timer
+        (run-with-timer 10 nil `(lambda ()
+                                  (when (buffer-live-p (get-buffer ,notification-buffer))
+                                    (claude-code--dismiss-and-kill-buffer ,notification-buffer)))))))
 
 ;;;###autoload
 (defun claude-code-test-notification ()

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -106,7 +106,11 @@ MESSAGE is the notification message to include in the TODO entry."
               ;; Buffer is visible, just select the window
               (select-window window)
             ;; Buffer is not visible, display it
-            (switch-to-buffer target-buffer)))
+            (switch-to-buffer target-buffer))
+          ;; If using evil mode and this is a Claude buffer, enter insert mode
+          (when (and (boundp 'evil-mode) evil-mode
+                     (string-match-p "^\\*claude:" buffer-name))
+            (evil-insert-state)))
         (message "Switched to perspective: %s and navigated to buffer: %s" persp-name buffer-name)
         persp-name)
     (error "No perspective found for buffer: %s" buffer-name)))
@@ -139,6 +143,43 @@ MESSAGE is the notification message to include in the TODO entry."
         (message "Deleted entry and switching to workspace...")
         ;; Switch to workspace
         (claude-code--switch-to-workspace-for-buffer buffer-name)))))
+
+;;;; Notification dismissal system
+
+(defvar claude-code--notification-dismiss-active nil
+  "Whether notification dismiss mode is currently active.")
+
+(defvar claude-code--notification-buffer-name nil
+  "Name of the current notification buffer.")
+
+(defun claude-code--enable-notification-dismiss (buffer-name)
+  "Enable global notification dismissal for BUFFER-NAME."
+  (unless claude-code--notification-dismiss-active
+    (setq claude-code--notification-dismiss-active t
+          claude-code--notification-buffer-name buffer-name)
+    ;; Use overriding-local-map for higher precedence
+    (let ((map (make-sparse-keymap)))
+      (define-key map (kbd "<escape>") 'claude-code--dismiss-notification-if-visible)
+      (define-key map (kbd "q") 'claude-code--dismiss-notification-if-visible)
+      (setq overriding-local-map map))))
+
+(defun claude-code--disable-notification-dismiss ()
+  "Disable global notification dismissal and restore original ESC binding."
+  (when claude-code--notification-dismiss-active
+    (setq claude-code--notification-dismiss-active nil
+          claude-code--notification-buffer-name nil)
+    ;; Clear the overriding map
+    (setq overriding-local-map nil)))
+
+(defun claude-code--dismiss-notification-if-visible ()
+  "Dismiss notification if visible."
+  (interactive)
+  (when (and claude-code--notification-dismiss-active
+             claude-code--notification-buffer-name
+             (get-buffer-window claude-code--notification-buffer-name))
+    ;; Notification is visible, dismiss it
+    (kill-buffer claude-code--notification-buffer-name)
+    (claude-code--disable-notification-dismiss)))
 
 ;;;; Enhanced notification system
 
@@ -175,6 +216,11 @@ This is intended to be called from Claude Code hooks via emacsclient."
                              'action `(lambda (_button)
                                         (when (buffer-live-p ,target-buffer)
                                           (switch-to-buffer ,target-buffer)
+                                          ;; Enter insert mode if using evil
+                                          (when (and (boundp 'evil-mode) evil-mode
+                                                     (string-match-p "^\\*claude:" ,buffer-name-override))
+                                            (evil-insert-state))
+                                          (claude-code--disable-notification-dismiss)
                                           (kill-buffer ,notification-buffer)))
                              'help-echo (format "Click to switch to %s" buffer-name-override))
             (insert (format "Buffer '%s' not found or no longer exists." (or buffer-name-override "unknown"))))
@@ -184,6 +230,7 @@ This is intended to be called from Claude Code hooks via emacsclient."
             (insert-button "Open Workspace"
                            'action `(lambda (_button)
                                       (claude-code--switch-to-workspace-for-buffer ,buffer-name-override)
+                                      (claude-code--disable-notification-dismiss)
                                       (kill-buffer ,notification-buffer))
                            'help-echo (format "Click to switch to workspace for buffer: %s" buffer-name-override))
             (insert "   ")
@@ -191,6 +238,7 @@ This is intended to be called from Claude Code hooks via emacsclient."
                            'action `(lambda (_button)
                                       (claude-code--switch-to-workspace-for-buffer ,buffer-name-override)
                                       (claude-code--clear-most-recent-org-entry)
+                                      (claude-code--disable-notification-dismiss)
                                       (kill-buffer ,notification-buffer))
                            'help-echo (format "Click to switch to workspace and clear org entry for buffer: %s" buffer-name-override))
             (insert "\n"))
@@ -199,6 +247,7 @@ This is intended to be called from Claude Code hooks via emacsclient."
           (insert-button "View Task Queue"
                          'action `(lambda (_button)
                                     (find-file ,claude-code-taskmaster-org-file)
+                                    (claude-code--disable-notification-dismiss)
                                     (kill-buffer ,notification-buffer))
                          'help-echo "Click to view the org mode task queue")
           
@@ -206,7 +255,30 @@ This is intended to be called from Claude Code hooks via emacsclient."
           (setq buffer-read-only t))
         
         ;; Display the notification buffer
-        (display-buffer notification-buffer)))))
+        (let ((window (display-buffer notification-buffer)))
+          ;; Set up window-specific quit behavior like Doom popups
+          (set-window-parameter window 'quit-window 
+                                `(lambda ()
+                                   (interactive)
+                                   (claude-code--disable-notification-dismiss)
+                                   (quit-window nil ,window)))
+          
+          ;; Set up the notification dismiss system
+          (claude-code--enable-notification-dismiss notification-buffer)
+          
+          ;; Add quit-window keybinding to the buffer
+          (with-current-buffer notification-buffer
+            (local-set-key (kbd "q") `(lambda () 
+                                        (interactive) 
+                                        (claude-code--disable-notification-dismiss)
+                                        (quit-window)))
+            (local-set-key (kbd "<escape>") `(lambda () 
+                                               (interactive) 
+                                               (claude-code--disable-notification-dismiss)
+                                               (quit-window))))
+          
+
+          window)))))
 
 ;;;###autoload
 (defun claude-code-test-notification ()
@@ -233,31 +305,31 @@ This is intended to be called from Claude Code hooks via emacsclient."
                                                         (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(progn (require 'claude-code-org-notifications) (claude-code-handle-notification \\\"Claude session stopped\\\" \\\"$BUFFER\\\"))\""
                                                                             emacsclient-cmd)))]))])))))
          (existing-config (when (file-exists-p settings-file)
-                     (condition-case err
-                         (json-read-file settings-file)
-                       (error
-                        (message "Warning: Could not parse existing settings.json: %s" (error-message-string err))
-                        nil))))
-  (new-config (if existing-config
-                  (let ((config-alist (if (hash-table-p existing-config)
-                                          (claude-code--hash-table-to-alist existing-config)
-                                        existing-config)))
-                    (claude-code--merge-hooks-config config-alist hooks-config))
-                hooks-config)))
+                            (condition-case err
+                                (json-read-file settings-file)
+                              (error
+                               (message "Warning: Could not parse existing settings.json: %s" (error-message-string err))
+                               nil))))
+         (new-config (if existing-config
+                         (let ((config-alist (if (hash-table-p existing-config)
+                                                 (claude-code--hash-table-to-alist existing-config)
+                                               existing-config)))
+                           (claude-code--merge-hooks-config config-alist hooks-config))
+                       hooks-config)))
 
-(unless emacsclient-cmd
-  (error "emacsclient not found in PATH. Please ensure Emacs server is properly installed"))
+    (unless emacsclient-cmd
+      (error "emacsclient not found in PATH. Please ensure Emacs server is properly installed"))
 
-;; Ensure Claude directory exists
-(unless (file-directory-p claude-dir)
-  (make-directory claude-dir t))
+    ;; Ensure Claude directory exists
+    (unless (file-directory-p claude-dir)
+      (make-directory claude-dir t))
 
-;; Write updated config with pretty formatting
-(with-temp-file settings-file
-  (let ((json-encoding-pretty-print t))
-    (insert (json-encode new-config))))
+    ;; Write updated config with pretty formatting
+    (with-temp-file settings-file
+      (let ((json-encoding-pretty-print t))
+        (insert (json-encode new-config))))
 
-(message "Claude Code notification hooks added to %s" settings-file)))
+    (message "Claude Code notification hooks added to %s" settings-file)))
 
 (defun claude-code--hash-table-to-alist (hash-table)
   "Convert HASH-TABLE to an alist."
@@ -301,13 +373,14 @@ This is intended to be called from Claude Code hooks via emacsclient."
 
 ;;;; Integration
 
-;; Check if Doom Emacs is available and configure popup rule
-(when (and (boundp 'doom-version) (fboundp 'set-popup-rule!))
-  (set-popup-rule! "^\\*Claude Code Notification\\*$"
-    :side 'bottom
-    :size 0.3
-    :select nil
-    :quit t))
+;; Configure display rule for notification buffer
+(add-to-list 'display-buffer-alist
+             '("^\\*Claude Code Notification\\*$"
+               (display-buffer-in-side-window)
+               (side . bottom)
+               (window-height . 0.3)
+               (select . nil)
+               (quit-window . kill)))
 
 (provide 'claude-code-org-notifications)
 

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -99,11 +99,13 @@ MESSAGE is the notification message to include in the TODO entry."
                  return workspace-name)))))
 
 (defun claude-code--switch-to-workspace-for-buffer (buffer-name)
-  "Switch to the workspace that contains the specified BUFFER-NAME."
+  "Switch to the workspace that contains the specified BUFFER-NAME and switch to the buffer."
   (if-let ((workspace-name (claude-code--find-workspace-for-buffer buffer-name)))
       (progn
         (+workspace/switch-to workspace-name)
-        (message "Switched to workspace: %s" workspace-name)
+        (when (get-buffer buffer-name)
+          (switch-to-buffer buffer-name))
+        (message "Switched to workspace: %s and buffer: %s" workspace-name buffer-name)
         workspace-name)
     (error "No workspace found for buffer: %s" buffer-name)))
 

--- a/claude-code-org-notifications.el
+++ b/claude-code-org-notifications.el
@@ -14,6 +14,15 @@
 ;;; Code:
 
 (require 'json)
+(require 'cl-lib)
+
+;; Declare functions from Doom Emacs workspaces
+(declare-function +workspace-list-names "workspaces")
+(declare-function +workspace-get "workspaces")
+(declare-function +workspace/switch-to "workspaces")
+(declare-function +workspace/switch-to-0 "workspaces")
+(declare-function +workspace-buffer-list "workspaces")
+(declare-function persp-parameter "persp-mode")
 
 ;;;; Customization
 
@@ -55,7 +64,7 @@ MESSAGE is the notification message to include in the TODO entry."
                         "Unknown buffer"))
          (workspace-dir (claude-code--get-workspace-from-buffer-name buffer-name))
          (workspace-link (if workspace-dir
-                             (format "[[elisp:(let ((default-directory \"%s\")) (+workspace/switch-to-0))][%s]]" workspace-dir (file-name-nondirectory (directory-file-name workspace-dir)))
+                             (format "[[elisp:(claude-code--switch-to-workspace-for-buffer \"%s\")][%s]]" buffer-name (file-name-nondirectory (directory-file-name workspace-dir)))
                            "Unknown workspace")))
     (with-temp-buffer
       (when (file-exists-p claude-code-taskmaster-org-file)
@@ -77,6 +86,26 @@ MESSAGE is the notification message to include in the TODO entry."
       (goto-char (point-max))
       (when (re-search-backward "Workspace: .*elisp:(let ((default-directory \"\([^\"]+\)\"))" nil t)
         (match-string 1)))))
+
+(defun claude-code--find-workspace-for-buffer (buffer-name)
+  "Find the workspace that contains the specified BUFFER-NAME."
+  (when (and (boundp 'doom-version) (fboundp '+workspace-list-names))
+    (let ((target-buffer (get-buffer buffer-name)))
+      (when target-buffer
+        (cl-loop for workspace-name in (+workspace-list-names)
+                 for workspace = (+workspace-get workspace-name)
+                 when (and workspace
+                           (member target-buffer (+workspace-buffer-list workspace)))
+                 return workspace-name)))))
+
+(defun claude-code--switch-to-workspace-for-buffer (buffer-name)
+  "Switch to the workspace that contains the specified BUFFER-NAME."
+  (if-let ((workspace-name (claude-code--find-workspace-for-buffer buffer-name)))
+      (progn
+        (+workspace/switch-to workspace-name)
+        (message "Switched to workspace: %s" workspace-name)
+        workspace-name)
+    (error "No workspace found for buffer: %s" buffer-name)))
 
 (defun claude-code--clear-most-recent-org-entry ()
   "Clear (mark as DONE) the most recent TODO entry in the taskmaster org file."
@@ -131,18 +160,16 @@ This is intended to be called from Claude Code hooks via emacsclient."
           (when workspace-dir
             (insert-button "Open Workspace"
                            'action `(lambda (_button)
-                                      (let ((default-directory ,workspace-dir))
-                                        (+workspace/switch-to-0))
+                                      (claude-code--switch-to-workspace-for-buffer ,buffer-name-override)
                                       (kill-buffer ,notification-buffer))
-                           'help-echo (format "Click to switch to workspace: %s" workspace-dir))
+                           'help-echo (format "Click to switch to workspace for buffer: %s" buffer-name-override))
             (insert "   ")
             (insert-button "Open & Clear"
                            'action `(lambda (_button)
-                                      (let ((default-directory ,workspace-dir))
-                                        (+workspace/switch-to-0))
+                                      (claude-code--switch-to-workspace-for-buffer ,buffer-name-override)
                                       (claude-code--clear-most-recent-org-entry)
                                       (kill-buffer ,notification-buffer))
-                           'help-echo (format "Click to switch to workspace and clear org entry: %s" workspace-dir))
+                           'help-echo (format "Click to switch to workspace and clear org entry for buffer: %s" buffer-name-override))
             (insert "\n"))
           
           (insert "\n")
@@ -175,12 +202,12 @@ This is intended to be called from Claude Code hooks via emacsclient."
          (emacsclient-cmd (executable-find "emacsclient"))
          (hooks-config `((hooks . ((Notification . [((matcher . "")
                                                      (hooks . [((type . "command")
-                                                                (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(require 'claude-code-org-notifications) (claude-code-handle-notification \\\"Claude task completed\\\" \\\"$BUFFER\\\")\""
+                                                                (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(progn (require 'claude-code-org-notifications) (claude-code-handle-notification \\\"Claude task completed\\\" \\\"$BUFFER\\\"))\""
                                                                                     emacsclient-cmd)))]))])
 
                                    (Stop . [((matcher . "")
                                              (hooks . [((type . "command")
-                                                        (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(require 'claude-code-org-notifications) (claude-code-handle-notification \\\"Claude session stopped\\\" \\\"$BUFFER\\\")\""
+                                                        (command . ,(format "BUFFER=\"$CLAUDE_BUFFER_NAME\"; %s --eval \"(progn (require 'claude-code-org-notifications) (claude-code-handle-notification \\\"Claude session stopped\\\" \\\"$BUFFER\\\"))\""
                                                                             emacsclient-cmd)))]))])))))
          (existing-config (when (file-exists-p settings-file)
                      (condition-case err
@@ -235,9 +262,15 @@ This is intended to be called from Claude Code hooks via emacsclient."
   "Go to the most recent workspace from the taskmaster org file."
   (interactive)
   (if-let ((workspace-dir (claude-code--get-most-recent-workspace)))
-      (let ((default-directory workspace-dir))
-        (+workspace/switch-to-0)
-        (message "Switched to workspace: %s" workspace-dir))
+      ;; Try to find a Claude buffer in the workspace directory to use for detection
+      (let ((claude-buffers (cl-loop for buf in (buffer-list)
+                                     when (and (buffer-name buf)
+                                               (string-match-p "^\\*claude:" (buffer-name buf))
+                                               (string-match-p (regexp-quote workspace-dir) (buffer-name buf)))
+                                     return (buffer-name buf))))
+        (if claude-buffers
+            (claude-code--switch-to-workspace-for-buffer claude-buffers)
+          (message "No Claude buffer found for workspace directory: %s" workspace-dir)))
     (message "No recent workspace found in taskmaster.org")))
 
 ;;;###autoload
@@ -245,11 +278,18 @@ This is intended to be called from Claude Code hooks via emacsclient."
   "Go to the most recent workspace and clear the org entry."
   (interactive)
   (if-let ((workspace-dir (claude-code--get-most-recent-workspace)))
-      (progn
-        (let ((default-directory workspace-dir))
-          (+workspace/switch-to-0))
-        (claude-code--clear-most-recent-org-entry)
-        (message "Switched to workspace and cleared org entry: %s" workspace-dir))
+      ;; Try to find a Claude buffer in the workspace directory to use for detection
+      (let ((claude-buffers (cl-loop for buf in (buffer-list)
+                                     when (and (buffer-name buf)
+                                               (string-match-p "^\\*claude:" (buffer-name buf))
+                                               (string-match-p (regexp-quote workspace-dir) (buffer-name buf)))
+                                     return (buffer-name buf))))
+        (if claude-buffers
+            (progn
+              (claude-code--switch-to-workspace-for-buffer claude-buffers)
+              (claude-code--clear-most-recent-org-entry)
+              (message "Switched to workspace and cleared org entry for buffer: %s" claude-buffers))
+          (message "No Claude buffer found for workspace directory: %s" workspace-dir)))
     (message "No recent workspace found in taskmaster.org")))
 
 ;;;; Integration

--- a/claude-code.el
+++ b/claude-code.el
@@ -90,9 +90,9 @@ This controls how the return key and its modifiers behave in Claude buffers:
 `\"S\"' is the shift key.
 `\"s\"' is the hyper key, which is the COMMAND key on macOS."
   :type '(choice (const :tag "Newline on shift-return (s-return for newline, RET to send)" newline-on-shift-return)
-                 (const :tag "Newline on alt-return (M-return for newline, RET to send)" newline-on-alt-return)
-                 (const :tag "Shift-return to send (RET for newline, S-return to send)" shift-return-to-send)
-                 (const :tag "Super-return to send (RET for newline, s-return to send)" super-return-to-send))
+          (const :tag "Newline on alt-return (M-return for newline, RET to send)" newline-on-alt-return)
+          (const :tag "Shift-return to send (RET for newline, S-return to send)" shift-return-to-send)
+          (const :tag "Super-return to send (RET for newline, s-return to send)" super-return-to-send))
   :group 'claude-code)
 
 (defcustom claude-code-enable-notifications t
@@ -398,7 +398,7 @@ for each directory across multiple invocations.")
   "Terminal backend to use for Claude Code.
 Choose between \\='eat (default) and \\='vterm terminal emulators."
   :type '(radio (const :tag "Eat terminal emulator" eat)
-                (const :tag "Vterm terminal emulator" vterm))
+          (const :tag "Vterm terminal emulator" vterm))
   :group 'claude-code)
 
 ;;;;; Generic function definitions
@@ -1342,39 +1342,8 @@ MESSAGE is the notification body."
 TERMINAL is the eat terminal parameter (not used)."
   (when claude-code-enable-notifications
     (funcall claude-code-notification-function
-             "Claude Ready"
+             "Claude Reay"
              "Waiting for your response")))
-
-(defun claude-code-handle-notification (message)
-  "Handle notifications from Claude Code hooks with enhanced UI.
-
-MESSAGE is the notification message to display.
-Creates a notification buffer with the message and optionally adds a button
-to switch to the Claude buffer if CLAUDE_BUFFER_NAME environment variable
-is set."
-  (interactive)
-  (message "Claude: %s" message)
-  (let* ((buffer-name "*Claude Code Notification*")
-         (claude-buffer-name (getenv "CLAUDE_BUFFER_NAME")))
-    (with-current-buffer (get-buffer-create buffer-name)
-      (read-only-mode -1)
-      (erase-buffer)
-      (insert message)
-      (when claude-buffer-name
-        (insert "\n\n")
-        (insert-button (format "Switch to %s" claude-buffer-name)
-                       'action (lambda (_button)
-                                 (when-let ((buffer (get-buffer claude-buffer-name)))
-                                   (switch-to-buffer buffer)))
-                       'help-echo (format "Click to switch to %s buffer" claude-buffer-name)))
-      (read-only-mode 1)
-      (display-buffer (current-buffer)
-                      '((display-buffer-in-side-window)
-                        (side . bottom)
-                        (window-height . 0.3)
-                        (slot . 0))))
-    (when (fboundp 'alert)
-      (alert message :title "Claude Code"))))
 
 (defun claude-code--vterm-bell-detector (orig-fun process input)
   "Detect bell characters in vterm output and trigger notifications.
@@ -1782,6 +1751,50 @@ enter Claude commands."
        (claude-code-read-only-mode)
      (claude-code-exit-read-only-mode))))
 
+;;;; Notification System
+
+;;;###autoload
+(defun claude-code-handle-notification (buffer-name)
+  "Handle notification with clickable link to Claude BUFFER-NAME.
+
+Creates a notification buffer with a clickable button to switch to the
+specified Claude buffer. This is intended to be called from Claude Code
+hooks via emacsclient."
+  (let ((notification-buffer "*Claude Code Notification*")
+        (target-buffer (when buffer-name (get-buffer buffer-name))))
+    (with-current-buffer (get-buffer-create notification-buffer)
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (format "Claude notification for: %s\n\n" (or buffer-name "unknown buffer")))
+        
+        (if (and target-buffer (buffer-live-p target-buffer))
+            (insert-button "Switch to Claude buffer"
+                          'action (lambda (_button)
+                                    (when (buffer-live-p target-buffer)
+                                      (switch-to-buffer target-buffer)
+                                      (kill-buffer notification-buffer)))
+                          'help-echo (format "Click to switch to %s" buffer-name))
+          (insert (format "Buffer '%s' not found or no longer exists." (or buffer-name "unknown"))))
+        
+        (goto-char (point-min))
+        (setq buffer-read-only t))
+      
+      ;; Display the notification buffer
+      (display-buffer notification-buffer)
+      
+      ;; Auto-dismiss after 10 seconds
+      (run-with-timer 10 nil (lambda ()
+                              (when (buffer-live-p (get-buffer notification-buffer))
+                                (kill-buffer notification-buffer)))))))
+
+;; Check if Doom Emacs is available and configure popup rule
+(when (and (boundp 'doom-version) (fboundp 'set-popup-rule!))
+  (set-popup-rule! "^\\*Claude Code Notification\\*$"
+    :side 'bottom
+    :size 0.3
+    :select nil
+    :quit t))
+
 ;;;; Mode definition
 ;;;###autoload
 (define-minor-mode claude-code-mode
@@ -1793,16 +1806,6 @@ and managing Claude sessions."
   :lighter " Claude"
   :global t
   :group 'claude-code)
-
-;;;; Optional Doom Emacs configuration
-;; Uncomment the following line if using Doom Emacs to configure
-;; popup behavior for Claude Code notification buffers:
-;;
-;; (set-popup-rule! "^\\*Claude Code Notification\\*$"
-;;   :side 'bottom
-;;   :size 0.3
-;;   :select nil
-;;   :quit t)
 
 ;;;; Provide the feature
 (provide 'claude-code)

--- a/claude-code.el
+++ b/claude-code.el
@@ -745,11 +745,8 @@ _BACKEND is the terminal backend type (should be \\='vterm)."
   (advice-add 'vterm--filter :around #'claude-code--vterm-bell-detector)
   ;; Set up multi-line buffering to prevent flickering
   (advice-add 'vterm--filter :around #'claude-code--vterm-multiline-buffer-filter)
-  
-  ;; Export CLAUDE_BUFFER_NAME environment variable in the shell session
-  ;; This ensures child processes (like Claude Code hooks) can access it
-  (when-let ((buffer-name (buffer-name)))
-    (vterm-send-string (format "export CLAUDE_BUFFER_NAME='%s'\n" buffer-name))))
+
+  )
 
 (cl-defmethod claude-code--term-customize-faces ((_backend (eql vterm)))
   "Apply face customizations for vterm terminal.
@@ -1779,57 +1776,57 @@ hooks via emacsclient."
         
         (if (and target-buffer (buffer-live-p target-buffer))
             (insert-button "Switch to Claude buffer"
-                          'action (lambda (_button)
-                                    (when (buffer-live-p target-buffer)
-                                      (switch-to-buffer target-buffer)
-                                      (kill-buffer notification-buffer)))
-                          'help-echo (format "Click to switch to %s" actual-buffer-name))
-          (insert (format "Buffer '%s' not found or no longer exists." (or actual-buffer-name "unknown"))))
-        
-        (goto-char (point-min))
-        (setq buffer-read-only t))
-      
-      ;; Display the notification buffer
-      (display-buffer notification-buffer)
-      
-      ;; Auto-dismiss after 10 seconds
-      (run-with-timer 10 nil (lambda ()
-                              (when (buffer-live-p (get-buffer notification-buffer))
-                                (kill-buffer notification-buffer)))))))
 
-;; Check if Doom Emacs is available and configure popup rule
-(when (and (boundp 'doom-version) (fboundp 'set-popup-rule!))
-  (set-popup-rule! "^\\*Claude Code Notification\\*$"
-    :side 'bottom
-    :size 0.3
-    :select nil
-    :quit t))
+        (if (and target-buffer (buffer-live-p target-buffer))
+            (insert-button "Switch to Claude buffer"
 
+                           (if (and target-buffer (buffer-live-p target-buffer))
+                               (insert-button "Switch to Claude buffer"
+                                              'action (lambda (_button)
+                                                        (when (buffer-live-p target-buffer)
+                                                          (switch-to-buffer target-buffer)
+                                                          (kill-buffer notification-buffer)))
+                                              'help-echo (format "Click to switch to %s" actual-buffer-name))
+                             (setq buffer-read-only t))
+
+                           ;; Display the notification buffer
+                           (display-buffer notification-buffer)
+
+                           ;; Auto-dismiss after 10 seconds
+                           (run-with-timer 10 nil (lambda ()
+
+                                                    ;; Auto-dismiss after 10 seconds
+
+                                                    (when (buffer-live-p (get-buffer notification-buffer))
+                                                      (kill-buffer notification-buffer)))))))
+      (set-popup-rule! "^\\*Claude Code Notification\\*$"
+        :side 'bottom
+        :size 0.3
+        :select nil
+        :quit t))
+;;;###autoload
 ;;;; Extensions
 
-;;;###autoload
-(defun claude-code-load-org-notifications ()
-  "Load the org mode notification queue extension for Claude Code.
+
+    (defun claude-code-load-org-notifications ()
+      "Load the org mode notification queue extension for Claude Code.
 
 This provides persistent task tracking in ~/.claude/taskmaster.org with
 timestamps and clickable buffer links, plus smart popup notifications."
-  (interactive)
-  (require 'claude-code-org-notifications)
-  (message "Claude Code org notifications loaded. Use M-x claude-code-setup-hooks to configure."))
+      (interactive)
+      (require 'claude-code-org-notifications)
+      (message "Claude Code org notifications loaded. Use M-x claude-code-setup-hooks to configure."))
 
 ;;;; Mode definition
-;;;###autoload
-(define-minor-mode claude-code-mode
-  "Minor mode for interacting with Claude AI CLI.
+
+    (define-minor-mode claude-code-mode
+      "Minor mode for interacting with Claude AI CLI.
 
 When enabled, provides functionality for starting, sending commands to,
 and managing Claude sessions."
-  :init-value nil
-  :lighter " Claude"
-  :global t
-  :group 'claude-code)
-
-;;;; Provide the feature
-(provide 'claude-code)
+      :init-value nil
+      :lighter " Claude"
+      :global t
+      :group 'claude-code)
 
 ;;; claude-code.el ends here

--- a/claude-code.el
+++ b/claude-code.el
@@ -744,7 +744,16 @@ _BACKEND is the terminal backend type (should be \\='vterm)."
   ;; Set up bell detection advice
   (advice-add 'vterm--filter :around #'claude-code--vterm-bell-detector)
   ;; Set up multi-line buffering to prevent flickering
-  (advice-add 'vterm--filter :around #'claude-code--vterm-multiline-buffer-filter))
+  (advice-add 'vterm--filter :around #'claude-code--vterm-multiline-buffer-filter)
+  
+  ;; Export CLAUDE_BUFFER_NAME environment variable in the shell session
+  ;; This ensures child processes (like Claude Code hooks) can access it
+  (when-let ((buffer-name (buffer-name)))
+    (run-with-idle-timer 0.1 nil
+                         (lambda ()
+                           (when (buffer-live-p (get-buffer buffer-name))
+                             (with-current-buffer buffer-name
+                               (vterm-send-string (format "export CLAUDE_BUFFER_NAME='%s'\n" buffer-name))))))))
 
 (cl-defmethod claude-code--term-customize-faces ((_backend (eql vterm)))
   "Apply face customizations for vterm terminal.
@@ -1336,6 +1345,37 @@ TERMINAL is the eat terminal parameter (not used)."
              "Claude Ready"
              "Waiting for your response")))
 
+(defun claude-code-handle-notification (message)
+  "Handle notifications from Claude Code hooks with enhanced UI.
+
+MESSAGE is the notification message to display.
+Creates a notification buffer with the message and optionally adds a button
+to switch to the Claude buffer if CLAUDE_BUFFER_NAME environment variable
+is set."
+  (interactive)
+  (message "Claude: %s" message)
+  (let* ((buffer-name "*Claude Code Notification*")
+         (claude-buffer-name (getenv "CLAUDE_BUFFER_NAME")))
+    (with-current-buffer (get-buffer-create buffer-name)
+      (read-only-mode -1)
+      (erase-buffer)
+      (insert message)
+      (when claude-buffer-name
+        (insert "\n\n")
+        (insert-button (format "Switch to %s" claude-buffer-name)
+                       'action (lambda (_button)
+                                 (when-let ((buffer (get-buffer claude-buffer-name)))
+                                   (switch-to-buffer buffer)))
+                       'help-echo (format "Click to switch to %s buffer" claude-buffer-name)))
+      (read-only-mode 1)
+      (display-buffer (current-buffer)
+                      '((display-buffer-in-side-window)
+                        (side . bottom)
+                        (window-height . 0.3)
+                        (slot . 0))))
+    (when (fboundp 'alert)
+      (alert message :title "Claude Code"))))
+
 (defun claude-code--vterm-bell-detector (orig-fun process input)
   "Detect bell characters in vterm output and trigger notifications.
 
@@ -1753,6 +1793,16 @@ and managing Claude sessions."
   :lighter " Claude"
   :global t
   :group 'claude-code)
+
+;;;; Optional Doom Emacs configuration
+;; Uncomment the following line if using Doom Emacs to configure
+;; popup behavior for Claude Code notification buffers:
+;;
+;; (set-popup-rule! "^\\*Claude Code Notification\\*$"
+;;   :side 'bottom
+;;   :size 0.3
+;;   :select nil
+;;   :quit t)
 
 ;;;; Provide the feature
 (provide 'claude-code)

--- a/claude-code.el
+++ b/claude-code.el
@@ -653,6 +653,9 @@ SWITCHES are optional command-line arguments for PROGRAM."
   (let* ((vterm-shell (if switches
                           (concat program " " (mapconcat #'identity switches " "))
                         program))
+         ;; Set environment variable with buffer name value
+         (vterm-environment (cons (format "CLAUDE_BUFFER_NAME=%s" buffer-name)
+                                  vterm-environment))
          (buffer (get-buffer-create buffer-name)))
     (with-current-buffer buffer
       ;; vterm needs to have an open window before starting the claude

--- a/claude-code.el
+++ b/claude-code.el
@@ -749,11 +749,7 @@ _BACKEND is the terminal backend type (should be \\='vterm)."
   ;; Export CLAUDE_BUFFER_NAME environment variable in the shell session
   ;; This ensures child processes (like Claude Code hooks) can access it
   (when-let ((buffer-name (buffer-name)))
-    (run-with-idle-timer 0.1 nil
-                         (lambda ()
-                           (when (buffer-live-p (get-buffer buffer-name))
-                             (with-current-buffer buffer-name
-                               (vterm-send-string (format "export CLAUDE_BUFFER_NAME='%s'\n" buffer-name))))))))
+    (vterm-send-string (format "export CLAUDE_BUFFER_NAME='%s'\n" buffer-name))))
 
 (cl-defmethod claude-code--term-customize-faces ((_backend (eql vterm)))
   "Apply face customizations for vterm terminal.
@@ -1754,18 +1750,32 @@ enter Claude commands."
 ;;;; Notification System
 
 ;;;###autoload
-(defun claude-code-handle-notification (buffer-name)
-  "Handle notification with clickable link to Claude BUFFER-NAME.
+(defun claude-code-handle-notification (message &optional buffer-name-override)
+  "Handle notification with clickable link to Claude buffer.
+
+MESSAGE is the notification message to display.
+BUFFER-NAME-OVERRIDE allows specifying a different buffer name than the
+environment variable. If MESSAGE looks like a buffer name (starts with *claude:),
+this function provides backwards compatibility by swapping the parameters.
 
 Creates a notification buffer with a clickable button to switch to the
 specified Claude buffer. This is intended to be called from Claude Code
 hooks via emacsclient."
-  (let ((notification-buffer "*Claude Code Notification*")
-        (target-buffer (when buffer-name (get-buffer buffer-name))))
+  (let* (;; Handle backwards compatibility: if message looks like a buffer name, swap parameters
+         (is-buffer-name (and message (string-match-p "^\\*claude:" message)))
+         (actual-message (if is-buffer-name 
+                             (or buffer-name-override "Task completed")
+                           message))
+         (actual-buffer-name (if is-buffer-name
+                                 message
+                               buffer-name-override))
+         (notification-buffer "*Claude Code Notification*")
+         (target-buffer (when actual-buffer-name (get-buffer actual-buffer-name))))
     (with-current-buffer (get-buffer-create notification-buffer)
       (let ((inhibit-read-only t))
         (erase-buffer)
-        (insert (format "Claude notification for: %s\n\n" (or buffer-name "unknown buffer")))
+        (insert (format "%s\n" (or actual-message "Claude notification")))
+        (insert (format "Buffer: %s\n\n" (or actual-buffer-name "unknown buffer")))
         
         (if (and target-buffer (buffer-live-p target-buffer))
             (insert-button "Switch to Claude buffer"
@@ -1773,8 +1783,8 @@ hooks via emacsclient."
                                     (when (buffer-live-p target-buffer)
                                       (switch-to-buffer target-buffer)
                                       (kill-buffer notification-buffer)))
-                          'help-echo (format "Click to switch to %s" buffer-name))
-          (insert (format "Buffer '%s' not found or no longer exists." (or buffer-name "unknown"))))
+                          'help-echo (format "Click to switch to %s" actual-buffer-name))
+          (insert (format "Buffer '%s' not found or no longer exists." (or actual-buffer-name "unknown"))))
         
         (goto-char (point-min))
         (setq buffer-read-only t))

--- a/claude-code.el
+++ b/claude-code.el
@@ -17,6 +17,10 @@
 (require 'project)
 (require 'cl-lib)
 
+;; Declare functions from claude-code-org-notifications.el
+(declare-function claude-code-goto-recent-workspace "claude-code-org-notifications")
+(declare-function claude-code-goto-recent-workspace-and-clear "claude-code-org-notifications")
+
 ;;;; Customization options
 (defgroup claude-code nil
   "Claude AI interface for Emacs."
@@ -321,6 +325,8 @@ for each directory across multiple invocations.")
     (define-key map (kbd "2") 'claude-code-send-2)
     (define-key map (kbd "3") 'claude-code-send-3)
     (define-key map (kbd "M") 'claude-code-cycle-mode)
+    (define-key map (kbd "w") 'claude-code-goto-recent-workspace)
+    (define-key map (kbd "W") 'claude-code-goto-recent-workspace-and-clear)
     map)
   "Keymap for Claude commands.")
 
@@ -358,6 +364,10 @@ for each directory across multiple invocations.")
     ("1" "Send \"1\"" claude-code-send-1)
     ("2" "Send \"2\"" claude-code-send-2)
     ("3" "Send \"3\"" claude-code-send-3)
+    ]
+   ["Workspace Navigation"
+    ("w" "Go to recent workspace" claude-code-goto-recent-workspace)
+    ("W" "Go to workspace and clear" claude-code-goto-recent-workspace-and-clear)
     ]])
 
 ;;;###autoload (autoload 'claude-code-slash-commands "claude-code" nil t)
@@ -1744,89 +1754,30 @@ enter Claude commands."
        (claude-code-read-only-mode)
      (claude-code-exit-read-only-mode))))
 
-;;;; Notification System
-
-;;;###autoload
-(defun claude-code-handle-notification (message &optional buffer-name-override)
-  "Handle notification with clickable link to Claude buffer.
-
-MESSAGE is the notification message to display.
-BUFFER-NAME-OVERRIDE allows specifying a different buffer name than the
-environment variable. If MESSAGE looks like a buffer name (starts with *claude:),
-this function provides backwards compatibility by swapping the parameters.
-
-Creates a notification buffer with a clickable button to switch to the
-specified Claude buffer. This is intended to be called from Claude Code
-hooks via emacsclient."
-  (let* (;; Handle backwards compatibility: if message looks like a buffer name, swap parameters
-         (is-buffer-name (and message (string-match-p "^\\*claude:" message)))
-         (actual-message (if is-buffer-name 
-                             (or buffer-name-override "Task completed")
-                           message))
-         (actual-buffer-name (if is-buffer-name
-                                 message
-                               buffer-name-override))
-         (notification-buffer "*Claude Code Notification*")
-         (target-buffer (when actual-buffer-name (get-buffer actual-buffer-name))))
-    (with-current-buffer (get-buffer-create notification-buffer)
-      (let ((inhibit-read-only t))
-        (erase-buffer)
-        (insert (format "%s\n" (or actual-message "Claude notification")))
-        (insert (format "Buffer: %s\n\n" (or actual-buffer-name "unknown buffer")))
-        
-        (if (and target-buffer (buffer-live-p target-buffer))
-            (insert-button "Switch to Claude buffer"
-
-        (if (and target-buffer (buffer-live-p target-buffer))
-            (insert-button "Switch to Claude buffer"
-
-                           (if (and target-buffer (buffer-live-p target-buffer))
-                               (insert-button "Switch to Claude buffer"
-                                              'action (lambda (_button)
-                                                        (when (buffer-live-p target-buffer)
-                                                          (switch-to-buffer target-buffer)
-                                                          (kill-buffer notification-buffer)))
-                                              'help-echo (format "Click to switch to %s" actual-buffer-name))
-                             (setq buffer-read-only t))
-
-                           ;; Display the notification buffer
-                           (display-buffer notification-buffer)
-
-                           ;; Auto-dismiss after 10 seconds
-                           (run-with-timer 10 nil (lambda ()
-
-                                                    ;; Auto-dismiss after 10 seconds
-
-                                                    (when (buffer-live-p (get-buffer notification-buffer))
-                                                      (kill-buffer notification-buffer)))))))
-      (set-popup-rule! "^\\*Claude Code Notification\\*$"
-        :side 'bottom
-        :size 0.3
-        :select nil
-        :quit t))
-;;;###autoload
 ;;;; Extensions
 
-
-    (defun claude-code-load-org-notifications ()
-      "Load the org mode notification queue extension for Claude Code.
+;;;###autoload
+(defun claude-code-load-org-notifications ()
+  "Load the org mode notification queue extension for Claude Code.
 
 This provides persistent task tracking in ~/.claude/taskmaster.org with
 timestamps and clickable buffer links, plus smart popup notifications."
-      (interactive)
-      (require 'claude-code-org-notifications)
-      (message "Claude Code org notifications loaded. Use M-x claude-code-setup-hooks to configure."))
+  (interactive)
+  (require 'claude-code-org-notifications)
+  (message "Claude Code org notifications loaded. Use M-x claude-code-setup-hooks to configure."))
 
 ;;;; Mode definition
 
-    (define-minor-mode claude-code-mode
-      "Minor mode for interacting with Claude AI CLI.
+(define-minor-mode claude-code-mode
+  "Minor mode for interacting with Claude AI CLI.
 
 When enabled, provides functionality for starting, sending commands to,
 and managing Claude sessions."
-      :init-value nil
-      :lighter " Claude"
-      :global t
-      :group 'claude-code)
+  :init-value nil
+  :lighter " Claude"
+  :global t
+  :group 'claude-code)
+
+(provide 'claude-code)
 
 ;;; claude-code.el ends here

--- a/claude-code.el
+++ b/claude-code.el
@@ -1795,6 +1795,18 @@ hooks via emacsclient."
     :select nil
     :quit t))
 
+;;;; Extensions
+
+;;;###autoload
+(defun claude-code-load-org-notifications ()
+  "Load the org mode notification queue extension for Claude Code.
+
+This provides persistent task tracking in ~/.claude/taskmaster.org with
+timestamps and clickable buffer links, plus smart popup notifications."
+  (interactive)
+  (require 'claude-code-org-notifications)
+  (message "Claude Code org notifications loaded. Use M-x claude-code-setup-hooks to configure."))
+
 ;;;; Mode definition
 ;;;###autoload
 (define-minor-mode claude-code-mode


### PR DESCRIPTION
## Summary

Adds a command station for managing multiple Claude instances across projects with org mode task tracking and workspace navigation.

**Note**: Still experimenting with the best way to structure this workflow, opening as draft to gather feedback.

## Features

### Multi-Instance Command Station
- Single org file (`~/.claude/taskmaster.org`) tracks all Claude activities across projects
- Clickable notifications with ESC dismissal using `overriding-local-map`
- Navigate between workspaces containing Claude buffers via perspective.el
- Uses Claude Code's native `Notification` and `Stop` event hooks

### New Commands
- `claude-code-goto-recent-workspace` (`C-c c w`) - Navigate to most recent workspace with Claude activity
- `claude-code-goto-recent-workspace-and-clear` (`C-c c W`) - Navigate and mark org entry as done
- `claude-code-setup-hooks` - Configure notification hooks for multi-instance tracking

### Technical Implementation
- New file: `claude-code-org-notifications.el`
- Timestamped entries with clickable workspace links in org mode
- "Go to Workspace" and "Clear and Go to Workspace" action buttons
- Evil mode integration (enters insert mode when navigating to Claude buffers)
- Buffer-based workspace detection using `persp-buffers`

#### Environment Variable Integration
- Claude Code automatically exports `CLAUDE_BUFFER_NAME` environment variable to shell sessions
- Hook commands receive buffer name (e.g., `*claude:/path/to/project:default*`) via `$CLAUDE_BUFFER_NAME`
- This enables hooks to identify which specific Claude instance triggered the notification
- Used in emacsclient commands to pass buffer context to notification handlers

## Installation

The notification system is loaded automatically via `claude-code.el`. To enable org mode notifications:

```elisp
(claude-code-setup-hooks)
```

Optional dependency: perspective.el for workspace features

## Use Case

Track and navigate between multiple Claude instances running in different project directories from a single command station, with persistent task logging and quick workspace switching.

## Test Plan

- [ ] Run `claude-code-setup-hooks` and verify `~/.claude/settings.json` is created with notification hooks
- [ ] Start Claude instance and complete a task, verify entry appears in `~/.claude/taskmaster.org`
- [ ] Verify notification popup appears with clickable buttons when Claude buffer not visible
- [ ] Test ESC key dismisses notification popup
- [ ] Test "Go to Workspace" button switches to correct workspace and buffer
- [ ] Test "Clear and Go to Workspace" button clears org entry and switches workspace
- [ ] Test `C-c c w` command navigates to most recent workspace
- [ ] Test `C-c c W` command navigates and clears org entry
- [ ] With evil mode enabled, verify entering insert mode when navigating to Claude buffers
- [ ] Test with multiple Claude instances across different projects
- [ ] Verify workspace detection works with perspective.el

🤖 Generated with [Claude Code](https://claude.ai/code)