### PR TITLE
Add customizable vterm multiline delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
-## [Unreleased]
+### [0.4.3]
 
 ### Added
 - New `claude-code-vterm-multiline-delay` customization variable to control the delay before processing buffered vterm output
   - Default value changed from 0.001 to 0.01 seconds (10ms) to better reduce flickering
   - Allows fine-tuning the balance between flickering reduction and responsiveness
+  
+### Fixed
+- Fix bug in eat keybindings 
 
 ## [0.4.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- New `claude-code-vterm-multiline-delay` customization variable to control the delay before processing buffered vterm output
+  - Default value changed from 0.001 to 0.01 seconds (10ms) to better reduce flickering
+  - Allows fine-tuning the balance between flickering reduction and responsiveness
+
 ## [0.4.2]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -523,9 +523,15 @@ When using the vterm terminal backend, there are additional customization option
 ```elisp
 ;; Enable/disable buffering to prevent flickering on multi-line input (default is t)
 ;; When enabled, vterm output that appears to be redrawing multi-line input boxes
-;; will be buffered briefly (1ms) and processed in a single batch
+;; will be buffered briefly and processed in a single batch
 ;; This prevents flickering when Claude redraws its input box as it expands
 (setq claude-code-vterm-buffer-multiline-output t)
+
+;; Control the delay before processing buffered vterm output (default is 0.01)
+;; This is the time in seconds that vterm waits to collect output bursts
+;; A longer delay may reduce flickering more but could feel less responsive
+;; The default of 0.01 seconds (10ms) provides a good balance
+(setq claude-code-vterm-multiline-delay 0.01)
 ```
 
 #### Vterm Scrollback Configuration

--- a/claude-code.el
+++ b/claude-code.el
@@ -269,12 +269,25 @@ outputs."
   "Whether to buffer vterm output to prevent flickering on multi-line input.
 
 When non-nil, vterm output that appears to be redrawing multi-line
-input boxes will be buffered briefly (1ms) and processed in a single
+input boxes will be buffered briefly and processed in a single
 batch. This prevents the flickering that can occur when Claude redraws
 its input box as it expands to multiple lines.
 
 This only affects the vterm backend."
   :type 'boolean
+  :group 'claude-code-vterm)
+
+(defcustom claude-code-vterm-multiline-delay 0.01
+  "Delay in seconds before processing buffered vterm output.
+
+This controls how long vterm waits to collect output before processing
+it when `claude-code-vterm-buffer-multiline-output' is enabled.
+The delay should be long enough to collect bursts of updates but short
+enough to not be noticeable to the user.
+
+The default value of 0.01 seconds (10ms) provides a good balance
+between reducing flickering and maintaining responsiveness."
+  :type 'number
   :group 'claude-code-vterm)
 
 ;;;; Forward declrations for flycheck
@@ -1405,10 +1418,10 @@ INPUT is the terminal output string."
               ;; Cancel existing timer
               (when claude-code--vterm-multiline-buffer-timer
                 (cancel-timer claude-code--vterm-multiline-buffer-timer))
-              ;; Set timer with very short delay (1ms)
+              ;; Set timer with configurable delay
               ;; This is enough to collect a burst of updates but not noticeable to user
               (setq claude-code--vterm-multiline-buffer-timer
-                    (run-at-time 0.001 nil
+                    (run-at-time claude-code-vterm-multiline-delay nil
                                  (lambda (buf)
                                    (when (buffer-live-p buf)
                                      (with-current-buffer buf

--- a/full-changes.patch
+++ b/full-changes.patch
@@ -1,0 +1,264 @@
+diff --git a/claude-code.el b/claude-code.el
+index 7f7b6c2..c23573a 100644
+--- a/claude-code.el
++++ b/claude-code.el
+@@ -293,6 +293,18 @@ for each directory across multiple invocations.")
+ (defvar claude-code--window-widths nil
+   "Hash table mapping windows to their last known widths for eat terminals.")
+ 
++(defvar-local claude-code--vterm-last-output-time nil
++  "Time of last output received from vterm process.")
++
++(defvar-local claude-code--vterm-resize-timer nil
++  "Timer for applying deferred window resize to vterm.")
++
++(defvar-local claude-code--vterm-pending-resize nil
++  "Pending resize dimensions (width . height) waiting to be sent to vterm.")
++
++(defvar-local claude-code--vterm-multiline-buffer-timer nil
++  "Timer for processing buffered multi-line vterm output.")
++
+ ;;;; Key bindings
+ ;;;###autoload (autoload 'claude-code-command-map "claude-code")
+ (defvar claude-code-command-map
+@@ -621,9 +633,6 @@ _BACKEND is the terminal backend type (should be \\='eat)."
+ 
+     (use-local-map map)))
+ 
+-(cl-defgeneric claude-code--term-get-adjust-process-window-size-fn (backend)
+-  "Get the BACKEND specific function that adjusts window size.")
+-
+ (cl-defmethod claude-code--term-get-adjust-process-window-size-fn ((_backend (eql eat)))
+   "Get the BACKEND specific function that adjusts window size."
+   #'eat--adjust-process-window-size)
+@@ -636,8 +645,10 @@ _BACKEND is the terminal backend type (should be \\='eat)."
+ (defvar vterm-environment)
+ (defvar vterm-shell)
+ (defvar vterm-term-environment-variable)
++(defvar vterm--term)
+ (declare-function vterm "vterm" (&optional buffer-name))
+ (declare-function vterm--window-adjust-process-window-size "vterm" (process window))
++(declare-function vterm--set-size "vterm" (vterm-term rows cols))
+ (declare-function vterm-copy-mode "vterm" (&optional arg))
+ (declare-function vterm-mode "vterm")
+ (declare-function vterm-send-key "vterm" key &optional shift meta ctrl accept-proc-output)
+@@ -1043,7 +1054,12 @@ If FORCE-PROMPT is non-nil, always prompt even if no instances exist."
+       ;; Remove vterm advice if using vterm backend
+       (when (eq claude-code-terminal-backend 'vterm)
+         (advice-remove 'vterm--filter #'claude-code--vterm-bell-detector)
+-        (advice-remove 'vterm--filter #'claude-code--vterm-multiline-buffer-filter))
++        (advice-remove 'vterm--filter #'claude-code--vterm-multiline-buffer-filter)
++        ;; Cancel any pending timers
++        (when claude-code--vterm-resize-timer
++          (cancel-timer claude-code--vterm-resize-timer))
++        (when claude-code--vterm-multiline-buffer-timer
++          (cancel-timer claude-code--vterm-multiline-buffer-timer)))
+       ;; Clean the window widths hash table
+       (when claude-code--window-widths
+         (clrhash claude-code--window-widths))
+@@ -1355,6 +1371,10 @@ TERMINAL is the eat terminal parameter (not used)."
+ ORIG-FUN is the original vterm--filter function.
+ PROCESS is the vterm process.
+ INPUT is the terminal output string."
++  ;; Track output timestamp for resize deferral
++  (with-current-buffer (process-buffer process)
++    (setq claude-code--vterm-last-output-time (current-time)))
++  
+   (when (and (string-match-p "\007" input)
+              (buffer-local-value 'claude-code-mode (process-buffer process))
+              ;; Ignore bells in OSC sequences (terminal title updates)
+@@ -1366,9 +1386,6 @@ INPUT is the terminal output string."
+ (defvar-local claude-code--vterm-multiline-buffer nil
+   "Buffer for accumulating multi-line vterm output.")
+ 
+-(defvar-local claude-code--vterm-multiline-buffer-timer nil
+-  "Timer for processing buffered multi-line vterm output.")
+-
+ (defun claude-code--vterm-multiline-buffer-filter (orig-fun process input)
+   "Buffer vterm output when it appears to be redrawing multi-line input.
+ This prevents flickering when Claude redraws its input box as it expands
+@@ -1382,52 +1399,106 @@ INPUT is the terminal output string."
+       ;; Feature disabled, pass through normally
+       (funcall orig-fun process input)
+     (with-current-buffer (process-buffer process)
+-      ;; Check if this looks like multi-line input box redraw
+-      ;; Common patterns when redrawing multi-line input:
+-      ;; - ESC[K (clear to end of line)
+-      ;; - ESC[<n>;<m>H (cursor positioning)
+-      ;; - ESC[<n>A/B/C/D (cursor movement)
+-      ;; - Multiple of these in sequence
+-      (let ((has-clear-line (string-match-p "\033\\[K" input))
+-            (has-cursor-pos (string-match-p "\033\\[[0-9]+;[0-9]+H" input))
+-            (has-cursor-move (string-match-p "\033\\[[0-9]*[ABCD]" input))
+-            (escape-count (cl-count ?\033 input)))
+-
+-        ;; If we see multiple escape sequences that look like redrawing,
+-        ;; or we're already buffering, add to buffer
+-        (if (or (and (>= escape-count 3)
+-                     (or has-clear-line has-cursor-pos has-cursor-move))
+-                claude-code--vterm-multiline-buffer)
+-            (progn
+-              ;; Add to buffer
+-              (setq claude-code--vterm-multiline-buffer
+-                    (concat claude-code--vterm-multiline-buffer input))
+-              ;; Cancel existing timer
+-              (when claude-code--vterm-multiline-buffer-timer
+-                (cancel-timer claude-code--vterm-multiline-buffer-timer))
+-              ;; Set timer with very short delay (1ms)
+-              ;; This is enough to collect a burst of updates but not noticeable to user
+-              (setq claude-code--vterm-multiline-buffer-timer
+-                    (run-at-time 0.001 nil
+-                                 (lambda (buf)
+-                                   (when (buffer-live-p buf)
+-                                     (with-current-buffer buf
+-                                       (when claude-code--vterm-multiline-buffer
+-                                         (let ((inhibit-redisplay t)
+-                                               (data claude-code--vterm-multiline-buffer))
+-                                           ;; Clear buffer first to prevent recursion
+-                                           (setq claude-code--vterm-multiline-buffer nil
+-                                                 claude-code--vterm-multiline-buffer-timer nil)
+-                                           ;; Process all buffered data at once
+-                                           (funcall orig-fun
+-                                                    (get-buffer-process buf)
+-                                                    data))))))
+-                                 (current-buffer))))
+-          ;; Not multi-line redraw, process normally
+-          (funcall orig-fun process input))))))
++      ;; Only buffer if we see strong indicators of multiline redraw
++      (let* ((has-clear-line (string-match-p "\033\\[K" input))
++             (has-cursor-up (string-match-p "\033\\[[0-9]*A" input))
++             (has-cursor-pos (string-match-p "\033\\[[0-9]+;[0-9]+H" input))
++             (escape-count (cl-count ?\033 input))
++             ;; Very specific pattern: clear line + cursor movement in same chunk
++             (is-multiline-redraw (and has-clear-line
++                                       (or has-cursor-up has-cursor-pos)
++                                       (>= escape-count 3))))
++
++        (cond
++         ;; Start buffering only for very specific redraw pattern
++         (is-multiline-redraw
++          (setq claude-code--vterm-multiline-buffer input)
++          ;; Cancel existing timer
++          (when claude-code--vterm-multiline-buffer-timer
++            (cancel-timer claude-code--vterm-multiline-buffer-timer))
++          ;; Very short timer - just enough to batch a single redraw
++          (setq claude-code--vterm-multiline-buffer-timer
++                (run-at-time 0.005 nil
++                             #'claude-code--vterm-flush-multiline-buffer
++                             (current-buffer))))
++         
++         ;; If we're buffering and see more escape sequences, add to buffer
++         ((and claude-code--vterm-multiline-buffer
++               (> escape-count 0))
++          (setq claude-code--vterm-multiline-buffer
++                (concat claude-code--vterm-multiline-buffer input))
++          ;; Reset timer
++          (when claude-code--vterm-multiline-buffer-timer
++            (cancel-timer claude-code--vterm-multiline-buffer-timer))
++          (setq claude-code--vterm-multiline-buffer-timer
++                (run-at-time 0.005 nil
++                             #'claude-code--vterm-flush-multiline-buffer
++                             (current-buffer))))
++         
++         ;; Otherwise process normally
++         (t
++          (funcall orig-fun process input)))))))
++
++(defun claude-code--vterm-flush-multiline-buffer (buffer)
++  "Flush the accumulated multiline buffer for BUFFER."
++  (when (buffer-live-p buffer)
++    (with-current-buffer buffer
++      (when claude-code--vterm-multiline-buffer
++        (let ((inhibit-redisplay t)
++              (data claude-code--vterm-multiline-buffer))
++          ;; Clear buffer state
++          (setq claude-code--vterm-multiline-buffer nil
++                claude-code--vterm-multiline-buffer-timer nil)
++          ;; Process all buffered data at once with redisplay inhibited
++          (funcall (symbol-function 'vterm--filter)
++                   (get-buffer-process buffer)
++                   data))))))
++
++(defun claude-code--vterm-output-recent-p ()
++  "Check if vterm output was received recently.
++
++Returns t if output was received within the last 100ms."
++  (and claude-code--vterm-last-output-time
++       (< (float-time (time-subtract (current-time) claude-code--vterm-last-output-time))
++          0.1)))
++
++(defun claude-code--vterm-apply-deferred-resize (buffer)
++  "Apply deferred resize to vterm in BUFFER."
++  (when (buffer-live-p buffer)
++    (with-current-buffer buffer
++      (when claude-code--vterm-pending-resize
++        (let* ((size claude-code--vterm-pending-resize)
++               (width (car size))
++               (height (cdr size))
++               (process (get-buffer-process buffer))
++               (windows (get-buffer-window-list buffer))
++               ;; Save window positions before resize
++               (window-states (mapcar (lambda (win)
++                                        (cons win (cons (window-start win)
++                                                        (>= (window-point win)
++                                                            (- (point-max) 2)))))
++                                      windows)))
++          (setq claude-code--vterm-pending-resize nil)
++          (setq claude-code--vterm-resize-timer nil)
++          ;; Send the resize to vterm
++          (when (and process (process-live-p process))
++            (vterm--set-size vterm--term height width)
++            ;; Restore window positions after resize
++            (dolist (state window-states)
++              (let ((win (car state))
++                    (start (cadr state))
++                    (was-at-bottom (cddr state)))
++                (when (window-live-p win)
++                  (if was-at-bottom
++                      ;; If we were at bottom, stay at bottom
++                      (with-selected-window win
++                        (goto-char (point-max))
++                        (recenter -1))
++                    ;; Otherwise restore previous position
++                    (set-window-start win start t)))))))))))
+ 
+ (defun claude-code--adjust-window-size-advice (orig-fun &rest args)
+-  "Advice to only signal on width change.
++  "Advice to only signal on width change and defer during active output.
+ 
+ Works with `eat--adjust-process-window-size' or
+ `vterm--adjust-process-window-size' to prevent unnecessary reflows.
+@@ -1436,6 +1507,8 @@ Returns the size returned by ORIG-FUN only when the width of any Claude
+ window has changed, not when only the height has changed. This prevents
+ unnecessary terminal reflows when only vertical space changes.
+ 
++For vterm, also defers resize during active output to prevent scrolling issues.
++
+ ARGS is passed to ORIG-FUN unchanged."
+   (let ((result (apply orig-fun args)))
+     ;; Check all windows for Claude buffers
+@@ -1454,7 +1527,23 @@ ARGS is passed to ORIG-FUN unchanged."
+       ;; we're not in read-only mode. otherwise nil. Nil means do
+       ;; not send a window size changed event to the Claude process.
+       (if (and width-changed (not (claude-code--term-in-read-only-p claude-code-terminal-backend)))
+-          result
++          (cond
++           ;; For vterm backend, defer resize if output is recent
++           ((and (eq claude-code-terminal-backend 'vterm)
++                 (claude-code--vterm-output-recent-p))
++            ;; Store pending resize
++            (setq claude-code--vterm-pending-resize result)
++            ;; Cancel any existing timer
++            (when claude-code--vterm-resize-timer
++              (cancel-timer claude-code--vterm-resize-timer))
++            ;; Set timer to apply resize after output settles
++            (setq claude-code--vterm-resize-timer
++                  (run-at-time 0.15 nil
++                               #'claude-code--vterm-apply-deferred-resize
++                               (current-buffer)))
++            nil) ; Don't resize now
++           ;; Otherwise, resize immediately
++           (t result))
+         nil))))
+ 
+ ;;;; Interactive Commands


### PR DESCRIPTION
## Summary
- Added new `claude-code-vterm-multiline-delay` customization variable
- Changed default delay from 0.001 to 0.01 seconds (10ms) to better reduce flickering
- Updated documentation in README.md and CHANGELOG.md

## Details
This PR introduces a customization variable that allows users to configure the delay used when buffering vterm output to prevent flickering on multi-line input. The previous hardcoded value of 0.001 seconds (1ms) has been replaced with a customizable default of 0.01 seconds (10ms), which provides a better balance between reducing flickering and maintaining responsiveness.

Users can now fine-tune this value based on their specific setup and preferences.
