### PR TITLE
Handle remote paths in get-buffer-file-name

### DIFF
--- a/claude-code.el
+++ b/claude-code.el
@@ -1073,7 +1073,10 @@ the remembered directory->buffer associations."
 (defun claude-code--get-buffer-file-name ()
   "Get the file name associated with the current buffer."
   (when buffer-file-name
-    (file-truename buffer-file-name)))
+    (let ((file-name (file-truename buffer-file-name)))
+      (if (file-remote-p file-name)
+          (tramp-file-local-name file-name)
+        file-name))))
 
 (defun claude-code--format-file-reference (&optional file-name line-start line-end)
   "Format a file reference in the @file:line style.


### PR DESCRIPTION
If running Claude Code over tramp, `claude-code--get-buffer-file-name` will pass the path with the tramp prefix to Claude Code. This changes it so it only gets the local name.