### PR TITLE
Add claude-code-toggle-auto-select option to auto-focus Claude buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to claude-code.el will be documented in this file.
 ### Added
 - Claude Code hooks integration support for executing shell commands in response to tool calls (#70)
   - Allows custom automation via hook configurations in settings
+- New `claude-code-toggle-auto-select` customization option (#76)
+  - When set to `t`, automatically switches focus to Claude buffer after toggling it open
+  - Defaults to `nil` to preserve existing behavior
 
 ### Changed
 - Reorganized slash commands menu for better usability (#71)

--- a/README.md
+++ b/README.md
@@ -513,6 +513,12 @@ See the [Claude Code hooks documentation](https://docs.anthropic.com/en/docs/cla
 ;; when you run delete-other-windows or similar commands, keeping the
 ;; Claude buffer visible and accessible.
 (setq claude-code-no-delete-other-windows t)
+
+;; Automatically select the Claude buffer when toggling it open (default is nil)
+;; When set to t, claude-code-toggle will switch focus to the Claude buffer
+;; after displaying it. When nil, the buffer is displayed but focus remains
+;; in the current buffer.
+(setq claude-code-toggle-auto-select t)
 ```
 
 ### Customizing Window Position

--- a/claude-code.el
+++ b/claude-code.el
@@ -1,7 +1,7 @@
 ;;; claude-code.el --- Claude Code Emacs integration -*- lexical-binding: t; -*-
 
 ;; Author: Stephen Molitor <stevemolitor@gmail.com>
-;; Version: 0.2.0
+;; Version: 0.4.4
 ;; Package-Requires: ((emacs "30.0") (transient "0.9.3"))
 ;; Keywords: tools, ai
 ;; URL: https://github.com/stevemolitor/claude-code.el
@@ -174,6 +174,15 @@ When non-nil, claude-code will have the `no-delete-other-windows'
 parameter.  This parameter prevents the claude-code window from
 closing when calling `delete-other-windows' or any command that would
 launch a new full-screen buffer."
+  :type 'boolean
+  :group 'claude-code-window)
+
+(defcustom claude-code-toggle-auto-select nil
+  "Whether to automatically select the Claude buffer after toggling it open.
+
+When non-nil, `claude-code-toggle' will automatically switch to the
+Claude buffer when toggling it open.  When nil, the buffer will be
+displayed but focus will remain in the current buffer."
   :type 'boolean
   :group 'claude-code-window)
 
@@ -1587,7 +1596,10 @@ If the Claude buffer doesn't exist, create it."
             (delete-window (get-buffer-window claude-code-buffer))
           (let ((window (display-buffer claude-code-buffer '((display-buffer-below-selected)))))
             ;; set no-delete-other-windows parameter for claude-code window
-            (set-window-parameter window 'no-delete-other-windows claude-code-no-delete-other-windows)))
+            (set-window-parameter window 'no-delete-other-windows claude-code-no-delete-other-windows)
+            ;; Optionally select the window based on user preference
+            (when claude-code-toggle-auto-select
+              (select-window window))))
       (claude-code--show-not-running-message))))
 
 ;;;###autoload


### PR DESCRIPTION
## Summary
- Adds a new customization option `claude-code-toggle-auto-select` that allows users to automatically switch focus to the Claude buffer when toggling it open
- The option defaults to `nil` to preserve existing behavior
- When set to `t`, the `claude-code-toggle` function will automatically select the Claude window after displaying it

## Changes
- Added new `defcustom` option `claude-code-toggle-auto-select` in the window customization group
- Modified `claude-code-toggle` function to check the option and call `select-window` when appropriate
- Updated README with documentation for the new option
- Added CHANGELOG entry

## Testing
- Tested with `make all` - code compiles cleanly and passes checkdoc
- Manual testing confirms the feature works as expected

Fixes #76