### PR TITLE
Fix savehist pollution from interactive commands (fixes #101)

### DIFF
--- a/claude-code.el
+++ b/claude-code.el
@@ -357,6 +357,13 @@ for each directory across multiple invocations.")
 (defvar claude-code--window-widths nil
   "Hash table mapping windows to their last known widths for eat terminals.")
 
+(defvar claude-code-command-history nil
+  "History of commands sent to Claude.
+This is separate from Emacs' main variable `command-history' to prevent
+pollution when using `savehist-mode'.  Users can optionally save
+this history by adding `claude-code-command-history' to
+`savehist-additional-variables'.")
+
 ;;;; Key bindings
 ;;;###autoload (autoload 'claude-code-command-map "claude-code")
 (defvar claude-code-command-map
@@ -1738,23 +1745,25 @@ directories, allowing you to choose which one to switch to."
   (claude-code--kill-all-instances))
 
 ;;;###autoload
-(defun claude-code-send-command (cmd &optional arg)
+(defun claude-code-send-command (&optional arg)
   "Read a Claude command from the minibuffer and send it.
 
-With prefix ARG, switch to the Claude buffer after sending CMD."
-  (interactive "sClaude command: \nP")
-  (let ((selected-buffer (claude-code--do-send-command cmd)))
+With prefix ARG, switch to the Claude buffer after sending."
+  (interactive "P")
+  (let* ((cmd (read-string "Claude command: " nil 'claude-code-command-history))
+         (selected-buffer (claude-code--do-send-command cmd)))
     (when (and arg selected-buffer)
       (pop-to-buffer selected-buffer))))
 
 ;;;###autoload
-(defun claude-code-send-command-with-context (cmd &optional arg)
+(defun claude-code-send-command-with-context (&optional arg)
   "Read a Claude command and send it with current file and line context.
 
 If region is active, include region line numbers.
-With prefix ARG, switch to the Claude buffer after sending CMD."
-  (interactive "sClaude command: \nP")
-  (let* ((file-ref (if (use-region-p)
+With prefix ARG, switch to the Claude buffer after sending."
+  (interactive "P")
+  (let* ((cmd (read-string "Claude command: " nil 'claude-code-command-history))
+         (file-ref (if (use-region-p)
                        (claude-code--format-file-reference
                         nil
                         (line-number-at-pos (region-beginning))


### PR DESCRIPTION
## Summary
- Prevents `claude-code-send-command` and `claude-code-send-command-with-context` from polluting Emacs' `command-history`
- Fixes issue where user prompts (including sensitive/binary data) were being persisted by `savehist-mode`
- Introduces dedicated `claude-code-command-history` variable for Claude command history

## Problem
Interactive commands were using `(interactive "s...")` which automatically adds the complete function call with user input to Emacs' `command-history`. This caused `savehist-mode` to persist user prompts to disk, potentially including sensitive information or binary data.

## Solution
- Replace interactive "s" spec with `read-string` using a dedicated history variable
- Add new `claude-code-command-history` variable separate from main `command-history`
- Users can opt-in to save Claude command history by adding `claude-code-command-history` to `savehist-additional-variables`

## Testing
- [x] Code compiles without errors (`make compile`)
- [x] Passes checkdoc validation (`make checkdoc`)
- [x] Tested that commands no longer pollute `command-history`
- [x] Verified Claude command history is maintained in dedicated variable

Fixes #101