### PR TITLE
Fix line-number-at-pos calls for Emacs 30.1+ compatibility

### DIFF
--- a/claude-code.el
+++ b/claude-code.el
@@ -1757,8 +1757,8 @@ With prefix ARG, switch to the Claude buffer after sending CMD."
   (let* ((file-ref (if (use-region-p)
                        (claude-code--format-file-reference
                         nil
-                        (line-number-at-pos (region-beginning))
-                        (line-number-at-pos (region-end)))
+                        (line-number-at-pos (region-beginning) t)
+                        (line-number-at-pos (region-end) t))
                      (claude-code--format-file-reference)))
          (cmd-with-context (if file-ref
                                (format "%s\n%s" cmd file-ref)


### PR DESCRIPTION
Add the 't' parameter to line-number-at-pos calls to fix issue where line numbers were being calculated incorrectly when narrowing was in effect.

Fixes #96