### PR TITLE
fix: use inheritenv to work around buffer-local process-environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
+## Unreleased
+
+### Changed
+- Use `inheritenv` to make sure claude-code receives buffer-local process-environment in the vterm backend
+
 ## [0.4.5]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 
 - Emacs 30.0 or higher
 - [Claude Code CLI](https://github.com/anthropics/claude-code) installed and configured
-- Required: transient (0.7.5+)
+- Required: transient (0.7.5+) inheritenv (0.2)
 - Optional: eat (0.9.2+) for eat backend, vterm for vterm backend
   - Note: If not using a `:vc` install, the `eat` package requires NonGNU ELPA:
     ```elisp


### PR DESCRIPTION
envrc.el uses buffer-local environment variables, set using direnv. This ensures that commands launched from a project buffer inherit that project's direnv-set environment variables without any help from any shell plugin or special working around the underlying command.

Unfortunately, when we explicitly create a new buffer with get-buffer-create, this new buffer won't inherit the current environment.

As a result, the vterm-backend ends up launching claude code with an environment that does not reflect the desired, envrc

This results in not only the project's envrc not being used, but variables explicitly set by claude-code.el are also not correctly propagated to the underlying process.

To work around this, this commit uses the `inheritenv` macro to make sure vterm sees the adjusted project-environment when launching the process.