### PR TITLE
adds option to kill claude buffer on exit

### DIFF
--- a/claude-code.el
+++ b/claude-code.el
@@ -154,6 +154,15 @@ When nil, Claude instances will be killed without confirmation."
   :type 'boolean
   :group 'claude-code)
 
+(defcustom claude-code-kill-buffer-on-exit nil
+  "Whether to automatically kill the buffer when Claude process exits.
+
+When non-nil, the Claude buffer will be automatically killed when the
+Claude process finishes or exits.  When nil, the buffer will remain
+open for inspection even after the process has exited."
+  :type 'boolean
+  :group 'claude-code)
+
 (defcustom claude-code-optimize-window-resize t
   "Whether to optimize terminal window resizing to prevent unnecessary reflows.
 
@@ -1283,6 +1292,10 @@ With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt f
       ;; Add cleanup hook to remove directory mappings when buffer is killed
       (add-hook 'kill-buffer-hook #'claude-code--cleanup-directory-mapping nil t)
 
+      ;; Set up process sentinel for automatic buffer cleanup on exit
+      (when-let ((proc (get-buffer-process buffer)))
+        (set-process-sentinel proc #'claude-code--process-sentinel))
+
       ;; run start hooks
       (run-hooks 'claude-code-start-hook)
 
@@ -1510,6 +1523,24 @@ TERMINAL is the eat terminal parameter (not used)."
     (funcall claude-code-notification-function
              "Claude Ready"
              "Waiting for your response")))
+
+(defun claude-code--process-sentinel (process event)
+  "Process sentinel for Claude processes.
+
+PROCESS is the Claude process.
+EVENT is the process status change event string.
+
+When `claude-code-kill-buffer-on-exit' is non-nil, automatically
+kills the buffer associated with PROCESS when it exits."
+  (when (and claude-code-kill-buffer-on-exit
+             (memq (process-status process) '(exit signal))
+             (buffer-live-p (process-buffer process)))
+    ;; Give a brief moment for any final output to be processed
+    (run-at-time 0.1 nil
+                 (lambda (buf)
+                   (when (buffer-live-p buf)
+                     (kill-buffer buf)))
+                 (process-buffer process))))
 
 (defun claude-code--vterm-bell-detector (orig-fun process input)
   "Detect bell characters in vterm output and trigger notifications.


### PR DESCRIPTION
I am more comfortable keeping focus in the claude-code buffer, and so I end up quitting via /quit.  This feature kills the buffer when the process dies.  Pretty sure this feature would be useful to others?

- new defcustom `claude-code-kill-buffer-on-exit`; when non-nil, kill claude buffer when quitting manually with `/quit`
- new sentinel `claude-code--process-sentinel` that performs kill if appropriate.