### PR TITLE
Add live buffer preview for claude-code-here with consult

### DIFF
--- a/claude-code.el
+++ b/claude-code.el
@@ -1665,7 +1665,7 @@ If the Claude buffer doesn't exist, create it."
     (if claude-code-buffer
         (if (get-buffer-window claude-code-buffer)
             (delete-window (get-buffer-window claude-code-buffer))
-          (let ((window (display-buffer claude-code-buffer '((display-buffer-below-selected)))))
+          (let ((window (funcall claude-code-display-window-fn claude-code-buffer)))
             ;; set no-delete-other-windows parameter for claude-code window
             (set-window-parameter window 'no-delete-other-windows claude-code-no-delete-other-windows)
             ;; Optionally select the window based on user preference

--- a/claude-code.el
+++ b/claude-code.el
@@ -162,6 +162,15 @@ When nil, Claude instances will be killed without confirmation."
   :type 'boolean
   :group 'claude-code)
 
+(defcustom claude-code-kill-buffer-on-exit nil
+  "Whether to automatically kill the buffer when Claude process exits.
+
+When non-nil, the Claude buffer will be automatically killed when the
+Claude process finishes or exits.  When nil, the buffer will remain
+open for inspection even after the process has exited."
+  :type 'boolean
+  :group 'claude-code)
+
 (defcustom claude-code-optimize-window-resize t
   "Whether to optimize terminal window resizing to prevent unnecessary reflows.
 
@@ -1323,6 +1332,10 @@ With double prefix ARG (\\[universal-argument] \\[universal-argument]), prompt f
       ;; Add cleanup hook to remove directory mappings when buffer is killed
       (add-hook 'kill-buffer-hook #'claude-code--cleanup-directory-mapping nil t)
 
+      ;; Set up process sentinel for automatic buffer cleanup on exit
+      (when-let ((proc (get-buffer-process buffer)))
+        (set-process-sentinel proc #'claude-code--process-sentinel))
+
       ;; run start hooks
       (run-hooks 'claude-code-start-hook)
 
@@ -1572,6 +1585,24 @@ Only active when `claude-code-sync-buffer-name-with-title' is non-nil."
                  (not (and current-instance
                            (string= title "* Claude Code*"))))
         (rename-buffer new-name t)))))
+
+(defun claude-code--process-sentinel (process event)
+  "Process sentinel for Claude processes.
+
+PROCESS is the Claude process.
+EVENT is the process status change event string.
+
+When `claude-code-kill-buffer-on-exit' is non-nil, automatically
+kills the buffer associated with PROCESS when it exits."
+  (when (and claude-code-kill-buffer-on-exit
+             (memq (process-status process) '(exit signal))
+             (buffer-live-p (process-buffer process)))
+    ;; Give a brief moment for any final output to be processed
+    (run-at-time 0.1 nil
+                 (lambda (buf)
+                   (when (buffer-live-p buf)
+                     (kill-buffer buf)))
+                 (process-buffer process))))
 
 (defun claude-code--vterm-bell-detector (orig-fun process input)
   "Detect bell characters in vterm output and trigger notifications.

--- a/claude-code.el
+++ b/claude-code.el
@@ -387,6 +387,7 @@ this history by adding `claude-code-command-history' to
     (define-key map (kbd "s") 'claude-code-send-command)
     (define-key map (kbd "S") 'claude-code-sandbox)
     (define-key map (kbd "t") 'claude-code-toggle)
+    (define-key map (kbd "h") 'claude-code-here)
     (define-key map (kbd "x") 'claude-code-send-command-with-context)
     (define-key map (kbd "y") 'claude-code-send-return)
     (define-key map (kbd "z") 'claude-code-toggle-read-only-mode)
@@ -423,6 +424,7 @@ this history by adding `claude-code-command-history' to
     ("/" "Slash Commands" claude-code-slash-commands)]
    ["Manage Claude"
     ("t" "Toggle claude window" claude-code-toggle)
+    ("h" "Claude here (replace window)" claude-code-here)
     ("b" "Switch to Claude buffer" claude-code-switch-to-buffer)
     ("B" "Select from all Claude buffers" claude-code-select-buffer)
     ("z" "Toggle read-only mode" claude-code-toggle-read-only-mode)
@@ -1691,6 +1693,34 @@ If the Claude buffer doesn't exist, create it."
             (when claude-code-toggle-auto-select
               (select-window window))))
       (claude-code--show-not-running-message))))
+
+;;;###autoload
+(defun claude-code-here ()
+  "Switch current window to a Claude buffer, with option to create new.
+
+Prompts for a Claude buffer to switch to.  The selection includes all
+running Claude instances plus an option to create a new instance.
+Unlike `claude-code-toggle', this replaces the current window's buffer
+rather than displaying in a separate window."
+  (interactive)
+  (let* ((all-buffers (claude-code--find-all-claude-buffers))
+         (choices (claude-code--buffers-to-choices all-buffers))
+         ;; Add "Make new instance" option at the beginning
+         (choices-with-new (cons '("+ New Claude instance" . :new) choices))
+         (selection (completing-read "Claude: "
+                                     (mapcar #'car choices-with-new)
+                                     nil t)))
+    (when selection
+      (let ((selected (cdr (assoc selection choices-with-new))))
+        (if (eq selected :new)
+            ;; Create new instance and switch to it in current window
+            (let ((claude-code-display-window-fn
+                   (lambda (buf)
+                     (switch-to-buffer buf)
+                     (selected-window))))
+              (call-interactively #'claude-code))
+          ;; Switch to existing buffer in current window
+          (switch-to-buffer selected))))))
 
 ;;;###autoload
 (defun claude-code--switch-to-all-instances-helper ()

--- a/claude-code.el
+++ b/claude-code.el
@@ -1214,7 +1214,8 @@ Returns the selected Claude buffer or nil."
           (sit-for 0.1)
           ;; Send Return
           (claude-code--term-send-string claude-code-terminal-backend (kbd "RET"))
-          (display-buffer claude-code-buffer))
+          (when claude-code-auto-display-on-send
+            (display-buffer claude-code-buffer)))
         claude-code-buffer)
     (claude-code--show-not-running-message)
     nil))
@@ -1229,6 +1230,15 @@ Returns the selected Claude buffer or nil."
 
 Must be callable with a buffer as its parameter."
   :type 'function)
+
+(defcustom claude-code-auto-display-on-send t
+  "Whether to automatically display the Claude buffer after sending commands.
+
+When non-nil, the Claude buffer is displayed after sending commands
+via `claude-code--do-send-command'.  When nil, the buffer remains
+hidden unless already visible."
+  :type 'boolean
+  :group 'claude-code)
 
 (defun claude-code--start (arg extra-switches &optional force-prompt force-switch-to-buffer)
   "Start Claude with given command-line EXTRA-SWITCHES.

--- a/claude-code.el
+++ b/claude-code.el
@@ -146,6 +146,14 @@ to provide visual feedback when Claude is ready for input."
   :type 'function
   :group 'claude-code)
 
+(defcustom claude-code-sync-buffer-name-with-title nil
+  "Whether to rename Claude buffers based on terminal title changes.
+
+When non-nil, buffer names will be updated to reflect the session name
+set by the Claude Code CLI via terminal title escape sequences."
+  :type 'boolean
+  :group 'claude-code)
+
 (defcustom claude-code-confirm-kill t
   "Whether to ask for confirmation before killing Claude instances.
 
@@ -639,7 +647,8 @@ _BACKEND is the terminal backend type (should be \\='eat)."
 
   ;; Configure bell handler - ensure eat-terminal exists
   (when (bound-and-true-p eat-terminal)
-    (eval '(setf (eat-term-parameter eat-terminal 'ring-bell-function) #'claude-code--notify)))
+    (eval '(setf (eat-term-parameter eat-terminal 'ring-bell-function) #'claude-code--notify))
+    (eval '(setf (eat-term-parameter eat-terminal 'set-title-function) #'claude-code--handle-title-change)))
 
   ;; fix wonky initial terminal layout that happens sometimes if we show the buffer before claude is ready
   (sleep-for claude-code-startup-delay))
@@ -1531,6 +1540,28 @@ TERMINAL is the eat terminal parameter (not used)."
     (funcall claude-code-notification-function
              "Claude Ready"
              "Waiting for your response")))
+
+(defun claude-code--handle-title-change (_terminal title)
+  "Handle terminal title change to TITLE.
+
+_TERMINAL is the eat terminal (not used).
+Renames the buffer to include the session name from TITLE.
+Ignores the default \"* Claude Code*\" title if the buffer already has
+a custom instance name set.
+Only active when `claude-code-sync-buffer-name-with-title' is non-nil."
+  (when (and claude-code-sync-buffer-name-with-title
+             title
+             (not (string-empty-p title)))
+    (let* ((current-name (buffer-name))
+           (dir (claude-code--extract-directory-from-buffer-name current-name))
+           (current-instance (claude-code--extract-instance-name-from-buffer-name current-name))
+           (new-name (format "*claude:%s:%s*" dir title)))
+      (when (and dir
+                 (not (string= current-name new-name))
+                 ;; Don't replace existing custom title with default "* Claude Code*"
+                 (not (and current-instance
+                           (string= title "* Claude Code*"))))
+        (rename-buffer new-name t)))))
 
 (defun claude-code--vterm-bell-detector (orig-fun process input)
   "Detect bell characters in vterm output and trigger notifications.

--- a/claude-code.el
+++ b/claude-code.el
@@ -999,16 +999,18 @@ Returns a list of buffer objects."
   "Extract the directory path from a Claude BUFFER-NAME.
 
 For example, *claude:/path/to/project/* returns /path/to/project/.
-For example, *claude:/path/to/project/:tests* returns /path/to/project/."
-  (when (string-match "^\\*claude:\\([^:]+\\)\\(?::\\([^*]+\\)\\)?\\*$" buffer-name)
+For example, *claude:/path/to/project/:tests* returns /path/to/project/.
+Handles uniquify suffixes like <2>."
+  (when (string-match "^\\*claude:\\([^:]+\\)\\(?::\\([^*]+\\)\\)?\\*\\(?:<[0-9]+>\\)?$" buffer-name)
     (match-string 1 buffer-name)))
 
 (defun claude-code--extract-instance-name-from-buffer-name (buffer-name)
   "Extract the instance name from a Claude BUFFER-NAME.
 
 For example, *claude:/path/to/project/:tests* returns \"tests\".
-For example, *claude:/path/to/project/* returns nil."
-  (when (string-match "^\\*claude:\\([^:]+\\)\\(?::\\([^*]+\\)\\)?\\*$" buffer-name)
+For example, *claude:/path/to/project/* returns nil.
+Handles uniquify suffixes like <2>."
+  (when (string-match "^\\*claude:\\([^:]+\\)\\(?::\\([^*]+\\)\\)?\\*\\(?:<[0-9]+>\\)?$" buffer-name)
     (match-string 2 buffer-name)))
 
 (defun claude-code--buffer-display-name (buffer)

--- a/claude-code.el
+++ b/claude-code.el
@@ -413,6 +413,7 @@ this history by adding `claude-code-command-history' to
     (define-key map (kbd "3") 'claude-code-send-3)
     (define-key map (kbd "M") 'claude-code-cycle-mode)
     (define-key map (kbd "o") 'claude-code-send-buffer-file)
+    (define-key map (kbd "O") 'claude-code-send-project-file)
     map)
   "Keymap for Claude commands.")
 
@@ -436,6 +437,7 @@ this history by adding `claude-code-command-history' to
     ("x" "Send command with context" claude-code-send-command-with-context)
     ("r" "Send region or buffer" claude-code-send-region)
     ("o" "Send buffer file" claude-code-send-buffer-file)
+    ("O" "Send project file" claude-code-send-project-file)
     ("e" "Fix error at point" claude-code-fix-error-at-point)
     ("f" "Fork conversation" claude-code-fork)
     ("/" "Slash Commands" claude-code-slash-commands)]
@@ -1978,6 +1980,25 @@ With two prefix ARGs, both add instructions and switch to Claude buffer."
             (when (and (equal arg '(16)) selected-buffer) ; Only switch buffer with C-u C-u
               (pop-to-buffer selected-buffer))))
       (error "Current buffer is not associated with a file"))))
+
+;;;###autoload
+(defun claude-code-send-project-file ()
+  "Select a file from the current project and send it to Claude.
+
+Uses `project-files' to list files in the current project and prompts
+for selection using `completing-read'."
+  (interactive)
+  (if-let ((project (project-current)))
+      (let* ((files (project-files project))
+             (root (project-root project))
+             (selected-file (completing-read "Send file to Claude: "
+                                             (mapcar (lambda (f)
+                                                       (file-relative-name f root))
+                                                     files)
+                                             nil t))
+             (full-path (expand-file-name selected-file root)))
+        (claude-code-send-file full-path))
+    (error "Not in a project")))
 
 (defun claude-code--send-meta-return ()
   "Send Meta-Return key sequence to the terminal."

--- a/claude-code.el
+++ b/claude-code.el
@@ -1253,6 +1253,15 @@ hidden unless already visible."
   :type 'boolean
   :group 'claude-code)
 
+(defcustom claude-code-use-consult-preview t
+  "Whether to use consult for live buffer preview in `claude-code-here'.
+
+When non-nil and consult is installed, `claude-code-here' shows a live
+preview of Claude buffers as you navigate through candidates.  When nil
+or consult is not available, falls back to standard `completing-read'."
+  :type 'boolean
+  :group 'claude-code)
+
 (defun claude-code--start (arg extra-switches &optional force-prompt force-switch-to-buffer)
   "Start Claude with given command-line EXTRA-SWITCHES.
 
@@ -1770,6 +1779,39 @@ If the Claude buffer doesn't exist, create it."
               (select-window window))))
       (claude-code--show-not-running-message))))
 
+(defun claude-code--buffer-preview-state (choices-alist)
+  "Create a state function for previewing Claude buffers.
+
+CHOICES-ALIST is an alist mapping display names to buffer objects.
+Returns a function suitable for consult's :state parameter that
+shows buffer contents as the user navigates through candidates."
+  (let ((orig-buf (current-buffer)))
+    (lambda (action cand)
+      (when (eq action 'preview)
+        (let ((buf (and cand (cdr (assoc cand choices-alist)))))
+          (cond
+           ((and buf (bufferp buf) (buffer-live-p buf))
+            (switch-to-buffer buf 'norecord))
+           ((buffer-live-p orig-buf)
+            (switch-to-buffer orig-buf 'norecord))))))))
+
+(defun claude-code--read-buffer-selection (prompt choices-alist)
+  "Read a buffer selection using PROMPT from CHOICES-ALIST.
+
+CHOICES-ALIST is an alist mapping display names to buffer objects or symbols.
+When `claude-code-use-consult-preview' is non-nil and consult is available,
+uses consult with live buffer preview.  Otherwise falls back to
+`completing-read'."
+  (let ((candidates (mapcar #'car choices-alist)))
+    (if (and claude-code-use-consult-preview
+             (fboundp 'consult--read))
+        (consult--read candidates
+                       :prompt prompt
+                       :require-match t
+                       :state (claude-code--buffer-preview-state choices-alist)
+                       :category 'buffer)
+      (completing-read prompt candidates nil t))))
+
 ;;;###autoload
 (defun claude-code-here ()
   "Switch current window to a Claude buffer, with option to create new.
@@ -1777,25 +1819,23 @@ If the Claude buffer doesn't exist, create it."
 Prompts for a Claude buffer to switch to.  The selection includes all
 running Claude instances plus an option to create a new instance.
 Unlike `claude-code-toggle', this replaces the current window's buffer
-rather than displaying in a separate window."
+rather than displaying in a separate window.
+
+When `claude-code-use-consult-preview' is non-nil and consult is
+installed, provides live buffer preview while navigating."
   (interactive)
   (let* ((all-buffers (claude-code--find-all-claude-buffers))
          (choices (claude-code--buffers-to-choices all-buffers))
-         ;; Add "Make new instance" option at the beginning
          (choices-with-new (cons '("+ New Claude instance" . :new) choices))
-         (selection (completing-read "Claude: "
-                                     (mapcar #'car choices-with-new)
-                                     nil t)))
+         (selection (claude-code--read-buffer-selection "Claude: " choices-with-new)))
     (when selection
       (let ((selected (cdr (assoc selection choices-with-new))))
         (if (eq selected :new)
-            ;; Create new instance and switch to it in current window
             (let ((claude-code-display-window-fn
                    (lambda (buf)
                      (switch-to-buffer buf)
                      (selected-window))))
               (call-interactively #'claude-code))
-          ;; Switch to existing buffer in current window
           (switch-to-buffer selected))))))
 
 ;;;###autoload


### PR DESCRIPTION
## Summary
- Add optional live buffer preview when selecting Claude buffers via `claude-code-here`
- Uses consult's `:state` mechanism to show buffer contents as you navigate candidates
- Gated by `claude-code-use-consult-preview` defcustom (default `t`)
- Falls back to standard `completing-read` when consult is not installed or feature is disabled

## Changes
- `claude-code-use-consult-preview` - new defcustom to control the feature
- `claude-code--buffer-preview-state` - creates consult state function for preview
- `claude-code--read-buffer-selection` - helper that handles consult vs completing-read

## Test plan
- [x] With consult installed: `M-x claude-code-here` shows live preview while navigating
- [ ] Without consult: falls back to standard completing-read
- [x] Set `claude-code-use-consult-preview` to nil: disables preview even with consult

🤖 Generated with [Claude Code](https://claude.com/claude-code)