### PR TITLE
fix: allow scrolling back in eat read-only mode

### DIFF
--- a/claude-code.el
+++ b/claude-code.el
@@ -600,8 +600,8 @@ possible, preventing the scrolling up issue when editing other buffers."
   (dolist (window windows)
     (if (eq window 'buffer)
         (goto-char (eat-term-display-cursor eat-terminal))
-      ;; Don't move the cursor around when in eat-emacs-mode
-      (when (not buffer-read-only)
+      ;; Don't move the cursor around when in eat-emacs-mode (read-only mode)
+      (when eat--semi-char-mode
         (let ((cursor-pos (eat-term-display-cursor eat-terminal)))
           ;; Always set point to cursor position
           (set-window-point window cursor-pos)


### PR DESCRIPTION
The synchronize-scroll function checked `buffer-read-only` to decide whether to snap the viewport back to the terminal cursor. However, `eat-emacs-mode` (used by read-only mode) does not set `buffer-read-only` to t — it clears `eat--semi-char-mode` instead. This caused the scroll function to keep pulling the user back to the bottom even in read-only mode, making it impossible to scroll through history.

Fix: check `eat--semi-char-mode` (which is what `claude-code--term-in-read-only-p` already uses) instead of `buffer-read-only`.