### PR TITLE
Adopt ghostel-set-title-function rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ The default value of `0.1` seconds works well with Claude Code. Since Claude oft
 When using the ghostel (libghostty) backend, claude-code.el configures a few ghostel options automatically in Claude buffers:
 
 - Disables ghostel's own `ghostel-kill-buffer-on-exit` so claude-code.el manages buffer cleanup.
-- Disables `ghostel-enable-title-tracking` so OSC title sequences don't rename the Claude buffer.
+- Sets `ghostel-set-title-function` to nil so OSC title sequences don't rename the Claude buffer.
 - Routes terminal bell events through `claude-code-notification-function` for consistent notifications.
 
 For general ghostel configuration (keybindings, colors, font settings, and so on), see the [ghostel documentation](https://github.com/dakra/ghostel).

--- a/claude-code.el
+++ b/claude-code.el
@@ -936,7 +936,7 @@ _BACKEND is the terminal backend type (should be \\='vterm)."
 (defvar ghostel--process)
 (defvar ghostel--copy-mode-active)
 (defvar ghostel-kill-buffer-on-exit)
-(defvar ghostel-enable-title-tracking)
+(defvar ghostel-set-title-function)
 (declare-function ghostel-exec "ghostel")
 (declare-function ghostel-send-string "ghostel")
 (declare-function ghostel-send-key "ghostel")
@@ -1022,7 +1022,7 @@ _BACKEND is the terminal backend type (should be \\='ghostel)."
               (claude-code--kill-buffer buf))
             nil t)
   ;; Prevent ghostel from renaming the buffer via OSC title sequences
-  (setq-local ghostel-enable-title-tracking nil)
+  (setq-local ghostel-set-title-function nil)
   ;; Route bell to claude-code notification system
   ;; (ghostel native module calls `ding' on BEL, which uses ring-bell-function)
   (setq-local ring-bell-function #'claude-code--ghostel-bell-handler)


### PR DESCRIPTION
I added a defcustom so users can add their own 'set-title-function'.
This also replaces the old ghostel-enable-title-tracking setting.

Sorry for this breaking change, but ghostel is still so young and not used by many so I think
making breaking changes for now is still ok instead of keeping obsolete stuff around.

Thanks.